### PR TITLE
Update 01_foundation.ipynb

### DIFF
--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -208,7 +208,7 @@
     "#export\n",
     "class BypassNewMeta(FixSigMeta):\n",
     "    \"Metaclass: casts `x` to this class if it's of type `cls._bypass_type`, initializing with `_new_meta` if available\"\n",
-    "    def __call__(cls, x=None, *args, **kwargs):\n",
+    "    def __call__(cls, x, *args, **kwargs):\n",
     "        if hasattr(cls, '_new_meta'): x = cls._new_meta(x, *args, **kwargs)\n",
     "        elif not isinstance(x,getattr(cls,'_bypass_type',object)) or len(args) or len(kwargs):\n",
     "            x = super().__call__(*((x,)+args), **kwargs)\n",


### PR DESCRIPTION
I am finding `BypassNewMeta` really hard to follow and to understand it's use case. Thought I'd maybe raise this as `fastcore` is now a standalone component but please disregard if this is not something that makes sense giving your time to.

I think the `x=None` in signature might be misleading, AFAIK it can never work when passed `None` (or not passed anything). If that is the case removing this adds a little bit of legibility. 