### PR TITLE
test_fail for functions with arguments

### DIFF
--- a/nbs/00_test.ipynb
+++ b/nbs/00_test.ipynb
@@ -59,9 +59,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def test_fail(f, msg='', contains=''):\n",
+    "def test_fail(f,*args, msg='', contains=''):\n",
     "    \"Fails with `msg` unless `f()` raises an exception and (optionally) has `contains` in `e.args`\"\n",
-    "    try: f()\n",
+    "    try: f(*args)\n",
     "    except Exception as e:\n",
     "        assert not contains or contains in str(e)\n",
     "        return\n",
@@ -78,7 +78,12 @@
     "test_fail(_fail, contains=\"foo\")\n",
     "\n",
     "def _fail(): raise Exception()\n",
-    "test_fail(_fail)"
+    "test_fail(_fail)\n",
+    "\n",
+    "def _fail(a): return\n",
+    "test_fail(_fail)\n",
+    "\n",
+    "test_fail(test_fail,_fail,0)"
    ]
   },
   {


### PR DESCRIPTION
Allows to test functions with arguments.

Also added these examples so they appear on the documentation:
```python
def _fail(a): return
test_fail(_fail)
test_fail(test_fail,_fail,0)
```