### PR TITLE
Fixed editable install command to work universally with most shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 -->
 
 # Welcome to fastcore
+
 > Python supercharged for the fastai library
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 -->
 
 # Welcome to fastcore
-
 > Python supercharged for the fastai library
 
 
@@ -24,7 +23,7 @@ For an [editable install](https://stackoverflow.com/questions/35064426/when-woul
 ```
 git clone https://github.com/fastai/fastcore
 cd fastcore
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 ## Tests

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@ summary: "Python supercharged for the fastai library"
 
 <pre><code>git clone https://github.com/fastai/fastcore
 cd fastcore
-pip install -e .[dev]</code></pre>
+pip install -e ".[dev]"</code></pre>
 
 </div>
 </div>

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -29,7 +29,7 @@
     "```\n",
     "git clone https://github.com/fastai/fastcore\n",
     "cd fastcore\n",
-    "pip install -e .[dev]\n",
+    "pip install -e \".[dev]\"\n",
     "```"
    ]
   },


### PR DESCRIPTION
This is the same fix as in https://github.com/fastai/fastai2/pull/80

The existing command in the README for an editable install is: `pip install -e .[dev]`.
This does not work in the `zsh` shell. And since MacOS is now defaulting to `zsh`, it becomes important for it to work with it as well.

Changing it to: `pip install -e ".[dev]"` makes it work with *both* `bash` and `zsh` (on ubuntu, macOS *and* Windows).

This GitHub issue adds more light into the issue, and it's potential solutions: https://github.com/mu-editor/mu/issues/852. 
This comment concludes that adding double quotes is a universal solution for most platforms and shells: https://github.com/mu-editor/mu/issues/852#issuecomment-499870171