### PR TITLE
Add torch.equal to the equals function.

### DIFF
--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -16,7 +16,9 @@ from uuid import uuid4
 
 # External modules
 import numpy as np
+import torch
 from numpy import array,ndarray
+from torch import Tensor
 from pdb import set_trace
 
 #Optional modules
@@ -65,6 +67,7 @@ def equals(a,b):
     if hasattr(a, '__array_eq__'): return a.__array_eq__(b)
     if hasattr(b, '__array_eq__'): return b.__array_eq__(a)
     cmp = (np.array_equal if one_is_instance(a, b, ndarray       ) else
+           torch.equal if one_is_instance(a, b, Tensor       ) else
            operator.eq    if one_is_instance(a, b, (str,dict,set)) else
            all_equal      if is_iter(a) or is_iter(b) else
            operator.eq)

--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -67,7 +67,7 @@ def equals(a,b):
     if hasattr(a, '__array_eq__'): return a.__array_eq__(b)
     if hasattr(b, '__array_eq__'): return b.__array_eq__(a)
     cmp = (np.array_equal if one_is_instance(a, b, ndarray       ) else
-           torch.equal if one_is_instance(a, b, Tensor       ) else
+           torch.equal    if one_is_instance(a, b, Tensor        ) else
            operator.eq    if one_is_instance(a, b, (str,dict,set)) else
            all_equal      if is_iter(a) or is_iter(b) else
            operator.eq)


### PR DESCRIPTION
The equals function is not using `torch.equal` to test if two tensors are equal (it does use `numpy.array_equal` for ndarrays). That results in pretty long testing times for a little larger tensors (e.g. a few seconds for `torch.zeros((3,800,1600))`.