### PR TITLE
feat(log_args): add but_as

### DIFF
--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -406,15 +406,14 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
         try:
             func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
         except Exception as e:
-            print(f'@log_args had an issue on {f.__qualname__} -> {e}')
             try:
                 # sometimes it happens because the signature does not reference some kwargs
                 sigp = dict(inspect.signature(f_insp).parameters)
                 key_no_sig = set(kwargs.keys())-set(sigp.keys())
                 xtra_kwargs={k:kwargs.pop(k) for k in key_no_sig}
                 func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
-            except Exception as e2:
-                print(f'ignoring extra kwargs did not solve the issue -> {e2}')
+            except:
+                print(f'@log_args had an issue on {f.__qualname__} -> {e}')
                 return return_val
         func_args.apply_defaults()
         log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}

--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -379,13 +379,19 @@ def using_attr(f, attr):
     return partial(_using_attr, f, attr)
 
 # Cell
-def log_args(f=None, *, to_return=False, but=''):
+def log_args(f=None, *, to_return=False, but=None, but_as=None):
     "Decorator to log function args in 'to.init_args'"
-    if f is None: return partial(log_args, to_return=to_return, but=but)
+    if f is None: return partial(log_args, to_return=to_return, but=but, but_as=but_as)
 
     if inspect.isclass(f):
-        f.__init__ = log_args(f.__init__, to_return=to_return, but=but)
+        f.__init__ = log_args(f.__init__, to_return=to_return, but=but, but_as=but_as)
         return f
+
+    but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()
+    but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()
+    but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))
+    if but_not_found: warnings.warn(f'@log_args did not find but args while wrapping {f.__qualname__} in {", ".join(b.__qualname__ for b in but_not_found)}')
+    setattr(f, '_log_args_but', but)
 
     @wraps(f)  # maintain original signature
     def _f(*args, **kwargs):
@@ -400,9 +406,9 @@ def log_args(f=None, *, to_return=False, but=''):
             func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
             func_args.apply_defaults()
         except Exception as e:
-            print(f'@log_args did not work on {f.__qualname__} -> {e}')
+            warnings.warn(f'@log_args did not work on {f.__qualname__} -> {e}')
             return return_val
-        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but.split(',')+['self']}
+        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but}
         inst = return_val if to_return else args[0]
         init_args = getattr(inst, 'init_args', {})
         init_args.update(log)

--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -390,13 +390,14 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
     but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()
     but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()
     but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))
-    if but_not_found: warnings.warn(f'@log_args did not find but args while wrapping {f.__qualname__} in {", ".join(b.__qualname__ for b in but_not_found)}')
+    if but_not_found: print(f'@log_args did not find but args while wrapping {f.__qualname__} in {", ".join(b.__qualname__ for b in but_not_found)}')
     setattr(f, '_log_args_but', but)
 
     @wraps(f)  # maintain original signature
     def _f(*args, **kwargs):
         return_val = f(*args, **kwargs)
-        f_insp,args_insp=f,args
+        f_insp,args_insp = f,args
+        xtra_kwargs = {}
         # some functions don't have correct signature (e.g. functions with @delegates such as Datasets.__init__) so we get the one from the class
         if '__init__' in f.__qualname__:
             # from https://stackoverflow.com/a/25959545/3474490
@@ -404,11 +405,20 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
             f_insp, args_insp = cls, args[1:]
         try:
             func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
-            func_args.apply_defaults()
         except Exception as e:
-            warnings.warn(f'@log_args did not work on {f.__qualname__} -> {e}')
-            return return_val
-        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but}
+            print(f'@log_args had an issue on {f.__qualname__} -> {e}')
+            try:
+                # sometimes it happens because the signature does not reference some kwargs
+                sigp = dict(inspect.signature(f_insp).parameters)
+                key_no_sig = set(kwargs.keys())-set(sigp.keys())
+                xtra_kwargs={k:kwargs.pop(k) for k in key_no_sig}
+                func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
+            except Exception as e2:
+                print(f'ignoring extra kwargs did not solve the issue -> {e2}')
+                return return_val
+        func_args.apply_defaults()
+        log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}
+        log = {f'{f.__qualname__}.{k}':v for k,v in log_dict.items() if k not in but}
         inst = return_val if to_return else args[0]
         init_args = getattr(inst, 'init_args', {})
         init_args.update(log)

--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -390,7 +390,7 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
     but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()
     but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()
     but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))
-    if but_not_found: print(f'@log_args did not find but args while wrapping {f.__qualname__} in {", ".join(b.__qualname__ for b in but_not_found)}')
+    if but_not_found: print(f'@log_args did not find args from but_as while wrapping {f.__qualname__} in {", ".join(b.__qualname__ for b in but_not_found)}')
     setattr(f, '_log_args_but', but)
 
     @wraps(f)  # maintain original signature

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -208,7 +208,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<__main__._t at 0x7f9db573bfa0>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def foo(self): return 1\n",
     "mk_class('_t', 'a', sup=GetAttr, doc='test doc', funcs=foo)\n",
@@ -254,7 +265,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"noop\" class=\"doc_header\"><code>noop</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L52\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>noop</code>(**`x`**=*`None`*, **\\*`args`**, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "Do nothing"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_doc(noop)"
    ]
@@ -273,7 +301,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"noops\" class=\"doc_header\"><code>noops</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L56\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>noops</code>(**`x`**=*`None`*, **\\*`args`**, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "Do nothing (method)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_doc(noops)"
    ]
@@ -868,7 +913,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, False, True, False)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "lt(3,5),gt(3,5),is_(None,None),in_(0,[1,2])"
    ]
@@ -884,7 +940,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, False, True, False)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "lt(5)(3),gt(5)(3),is_(None)(None),in_([1,2])(0)"
    ]
@@ -1344,13 +1411,19 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def log_args(f=None, *, to_return=False, but=''):\n",
-    "    \"Decorator to log function args in 'to.init_args'\"    \n",
-    "    if f is None: return partial(log_args, to_return=to_return, but=but)\n",
+    "def log_args(f=None, *, to_return=False, but=None, but_as=None):\n",
+    "    \"Decorator to log function args in 'to.init_args'\"\n",
+    "    if f is None: return partial(log_args, to_return=to_return, but=but, but_as=but_as)\n",
     "    \n",
     "    if inspect.isclass(f):\n",
-    "        f.__init__ = log_args(f.__init__, to_return=to_return, but=but)\n",
+    "        f.__init__ = log_args(f.__init__, to_return=to_return, but=but, but_as=but_as)\n",
     "        return f\n",
+    "    \n",
+    "    but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()\n",
+    "    but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()\n",
+    "    but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))    \n",
+    "    if but_not_found: warnings.warn(f'@log_args did not find but args while wrapping {f.__qualname__} in {\", \".join(b.__qualname__ for b in but_not_found)}')\n",
+    "    setattr(f, '_log_args_but', but)\n",
     "    \n",
     "    @wraps(f)  # maintain original signature\n",
     "    def _f(*args, **kwargs):\n",
@@ -1365,9 +1438,9 @@
     "            func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
     "            func_args.apply_defaults()\n",
     "        except Exception as e:\n",
-    "            print(f'@log_args did not work on {f.__qualname__} -> {e}')\n",
+    "            warnings.warn(f'@log_args did not work on {f.__qualname__} -> {e}')\n",
     "            return return_val\n",
-    "        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but.split(',')+['self']}\n",
+    "        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but}\n",
     "        inst = return_val if to_return else args[0]\n",
     "        init_args = getattr(inst, 'init_args', {})\n",
     "        init_args.update(log)\n",
@@ -1384,8 +1457,12 @@
     "\n",
     "* `to_return`: applies to return value if True (for functions), otherwise to `self` (for class instances)\n",
     "* `but`: args that we do not want to save separated by ','\n",
+    "* `but_as`: pull `but` arg from another `log_args` (which cannot have used `to_return=True`)\n",
     "\n",
-    "Note: `@log_args` needs to be placed below `@patch` and above `@funcs_kwargs` or `@delegates`"
+    "Notes:\n",
+    "\n",
+    "* `@log_args` needs to be placed below `@patch` and above `@funcs_kwargs` or `@delegates`\n",
+    "* when wrapping a class, it will wrap its `__init__` method"
    ]
   },
   {
@@ -1444,7 +1521,35 @@
     "class tst(tst_parent):\n",
     "    def __init__(self, b):\n",
     "        super().__init__(a=b)\n",
-    "test_eq(tst(1).init_args, {'tst_parent.__init__.a': 1, 'tst.__init__.b': 1})"
+    "test_eq(tst(1).init_args, {'tst_parent.__init__.a': 1, 'tst.__init__.b': 1})\n",
+    "\n",
+    "class tst_ref:\n",
+    "    def __init__(self, a, b, c, d):\n",
+    "        pass\n",
+    "class tst:\n",
+    "    def __init__(self, a=1, b=2, c=3, d=4):\n",
+    "        pass\n",
+    "test_warns(lambda: log_args(tst, but_as=tst_ref.__init__))\n",
+    "\n",
+    "@log_args(but='a,b')\n",
+    "class tst_ref:\n",
+    "    def __init__(self, a, b, c, d):\n",
+    "        pass\n",
+    "@log_args(but_as=tst_ref.__init__)\n",
+    "class tst:\n",
+    "    def __init__(self, a=1, b=2, c=3, d=4):\n",
+    "        pass\n",
+    "test_eq(tst().init_args, {'tst.__init__.c': 3, 'tst.__init__.d': 4})\n",
+    "\n",
+    "@log_args(but='a,b')\n",
+    "class tst_ref:\n",
+    "    def __init__(self, a, b, c, d):\n",
+    "        pass\n",
+    "@log_args(but='c', but_as=tst_ref.__init__)\n",
+    "class tst:\n",
+    "    def __init__(self, a=1, b=2, c=3, d=4):\n",
+    "        pass\n",
+    "test_eq(tst().init_args, {'tst.__init__.d': 4})"
    ]
   },
   {
@@ -1675,7 +1780,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('files')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "path = Path()\n",
     "t = path.ls()\n",
@@ -1698,7 +1814,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(PosixPath('../fastcore/__init__.py'), PosixPath('04_transform.ipynb'))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "lib_path = (path/'../fastcore')\n",
     "txt_files=lib_path.ls(file_type='text')\n",
@@ -2071,7 +2198,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converted 00_test.ipynb.\n",
+      "Converted 01_foundation.ipynb.\n",
+      "Converted 02_utils.ipynb.\n",
+      "Converted 03_dispatch.ipynb.\n",
+      "Converted 04_transform.ipynb.\n",
+      "Converted index.ipynb.\n"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "from nbdev.export import notebook2script\n",

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7fd9ab5be040>"
+       "<__main__._t at 0x7f969eaa3460>"
       ]
      },
      "execution_count": null,
@@ -1422,7 +1422,7 @@
     "    but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()\n",
     "    but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()\n",
     "    but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))    \n",
-    "    if but_not_found: print(f'@log_args did not find but args while wrapping {f.__qualname__} in {\", \".join(b.__qualname__ for b in but_not_found)}')\n",
+    "    if but_not_found: print(f'@log_args did not find args from but_as while wrapping {f.__qualname__} in {\", \".join(b.__qualname__ for b in but_not_found)}')\n",
     "    setattr(f, '_log_args_but', but)\n",
     "    \n",
     "    @wraps(f)  # maintain original signature\n",
@@ -1552,7 +1552,7 @@
     "class tst:\n",
     "    def __init__(self, a=1, b=2, c=3, d=4):\n",
     "        pass\n",
-    "test_stdout(lambda: log_args(tst, but_as=tst_ref.__init__), '@log_args did not find but args while wrapping tst.__init__ in tst_ref.__init__')\n",
+    "test_stdout(lambda: log_args(tst, but_as=tst_ref.__init__), '@log_args did not find args from but_as while wrapping tst.__init__ in tst_ref.__init__')\n",
     "\n",
     "@log_args(but='a,b')\n",
     "class tst_ref:\n",

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7f969eaa3460>"
+       "<__main__._t at 0x7f60cf986100>"
       ]
      },
      "execution_count": null,
@@ -1438,15 +1438,14 @@
     "        try:\n",
     "            func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
     "        except Exception as e:\n",
-    "            print(f'@log_args had an issue on {f.__qualname__} -> {e}')\n",
     "            try:\n",
     "                # sometimes it happens because the signature does not reference some kwargs                \n",
     "                sigp = dict(inspect.signature(f_insp).parameters)\n",
     "                key_no_sig = set(kwargs.keys())-set(sigp.keys())\n",
     "                xtra_kwargs={k:kwargs.pop(k) for k in key_no_sig}\n",
     "                func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
-    "            except Exception as e2:\n",
-    "                print(f'ignoring extra kwargs did not solve the issue -> {e2}')\n",
+    "            except:\n",
+    "                print(f'@log_args had an issue on {f.__qualname__} -> {e}')\n",
     "                return return_val\n",
     "        func_args.apply_defaults()\n",
     "        log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}\n",

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7f9db573bfa0>"
+       "<__main__._t at 0x7fd9ab5be040>"
       ]
      },
      "execution_count": null,
@@ -1422,13 +1422,14 @@
     "    but_as_args = L(getattr(b, '_log_args_but', None) for b in L(but_as)).concat()\n",
     "    but = (L(but.split(',') if but else None) + but_as_args + L('self')).unique()\n",
     "    but_not_found = L(b for b in L(but_as) if not hasattr(b, '_log_args_but'))    \n",
-    "    if but_not_found: warnings.warn(f'@log_args did not find but args while wrapping {f.__qualname__} in {\", \".join(b.__qualname__ for b in but_not_found)}')\n",
+    "    if but_not_found: print(f'@log_args did not find but args while wrapping {f.__qualname__} in {\", \".join(b.__qualname__ for b in but_not_found)}')\n",
     "    setattr(f, '_log_args_but', but)\n",
     "    \n",
     "    @wraps(f)  # maintain original signature\n",
     "    def _f(*args, **kwargs):\n",
     "        return_val = f(*args, **kwargs)\n",
-    "        f_insp,args_insp=f,args\n",
+    "        f_insp,args_insp = f,args\n",
+    "        xtra_kwargs = {}\n",
     "        # some functions don't have correct signature (e.g. functions with @delegates such as Datasets.__init__) so we get the one from the class\n",
     "        if '__init__' in f.__qualname__:\n",
     "            # from https://stackoverflow.com/a/25959545/3474490\n",
@@ -1436,17 +1437,39 @@
     "            f_insp, args_insp = cls, args[1:]\n",
     "        try:\n",
     "            func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
-    "            func_args.apply_defaults()\n",
     "        except Exception as e:\n",
-    "            warnings.warn(f'@log_args did not work on {f.__qualname__} -> {e}')\n",
-    "            return return_val\n",
-    "        log = {f'{f.__qualname__}.{k}':v for k,v in func_args.arguments.items() if k not in but}\n",
+    "            print(f'@log_args had an issue on {f.__qualname__} -> {e}')\n",
+    "            try:\n",
+    "                # sometimes it happens because the signature does not reference some kwargs                \n",
+    "                sigp = dict(inspect.signature(f_insp).parameters)\n",
+    "                key_no_sig = set(kwargs.keys())-set(sigp.keys())\n",
+    "                xtra_kwargs={k:kwargs.pop(k) for k in key_no_sig}\n",
+    "                func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
+    "            except Exception as e2:\n",
+    "                print(f'ignoring extra kwargs did not solve the issue -> {e2}')\n",
+    "                return return_val\n",
+    "        func_args.apply_defaults()\n",
+    "        log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}\n",
+    "        log = {f'{f.__qualname__}.{k}':v for k,v in log_dict.items() if k not in but}\n",
     "        inst = return_val if to_return else args[0]\n",
     "        init_args = getattr(inst, 'init_args', {})\n",
     "        init_args.update(log)\n",
     "        setattr(inst, 'init_args', init_args)\n",
     "        return return_val\n",
     "    return _f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class tst:\n",
+    "    @log_args\n",
+    "    def __init__(self, a, b, c=3, d=4):\n",
+    "        pass\n",
+    "test_eq(tst(1,2).init_args, {f'tst.__init__.{k}':v for k,v in dict(a=1,b=2,c=3,d=4).items()})"
    ]
   },
   {
@@ -1529,7 +1552,7 @@
     "class tst:\n",
     "    def __init__(self, a=1, b=2, c=3, d=4):\n",
     "        pass\n",
-    "test_warns(lambda: log_args(tst, but_as=tst_ref.__init__))\n",
+    "test_stdout(lambda: log_args(tst, but_as=tst_ref.__init__), '@log_args did not find but args while wrapping tst.__init__ in tst_ref.__init__')\n",
     "\n",
     "@log_args(but='a,b')\n",
     "class tst_ref:\n",


### PR DESCRIPTION
Following changes:

* added `but_as`
* try to handle error where some args not in signature but add `(not in signature)` to the key name
* added tests for but_as and for expected warnings

Now the error on `21_vision_learner.py` related to `dls = pets.dataloaders(…)` logs following args (some say "not in signature" like `item_tfms` and `batch_tfms`):

```python
{'DataLoader.__init__.bs': 64,
 'DataLoader.__init__.num_workers': 4,
 'DataLoader.__init__.pin_memory': False,
 'DataLoader.__init__.timeout': 0,
 'DataLoader.__init__.batch_size': None,
 'DataLoader.__init__.shuffle': True,
 'DataLoader.__init__.drop_last': True,
 'DataLoader.__init__.indexed': None,
 'DataLoader.__init__.n': None,
 'DataLoader.__init__.device': device(type='cuda', index=0),
 'DataLoader.__init__.before_iter': None,
 'DataLoader.__init__.after_item': Pipeline: ToTensor,
 'DataLoader.__init__.before_batch': Pipeline: ,
 'DataLoader.__init__.after_batch': Pipeline: IntToFloatTensor,
 'DataLoader.__init__.after_iter': None,
 'DataLoader.__init__.batch_tfms (not in signature)': [AffineCoordTfm: (TensorBBox,object) -> encodes
  (TensorPoint,object) -> encodes
  (TensorImage,object) -> encodes
  (TensorMask,object) -> encodes ,
  LightingTfm: (TensorImage,object) -> encodes ],
 'DataLoader.__init__.item_tfms (not in signature)': RandomResizedCrop: (TensorBBox,object) -> encodes
 (TensorPoint,object) -> encodes
 (Image,object) -> encodes ,
 'TfmdDL.__init__.bs': 64,
 'TfmdDL.__init__.shuffle': True,
 'TfmdDL.__init__.num_workers': None,
 'TfmdDL.__init__.verbose': False,
 'TfmdDL.__init__.do_setup': True,
 'TfmdDL.__init__.pin_memory': False,
 'TfmdDL.__init__.timeout': 0,
 'TfmdDL.__init__.batch_size': None,
 'TfmdDL.__init__.drop_last': True,
 'TfmdDL.__init__.indexed': None,
 'TfmdDL.__init__.n': None,
 'TfmdDL.__init__.device': device(type='cuda', index=0),
 'TfmdDL.__init__.before_iter': None,
 'TfmdDL.__init__.after_item': (#1) [ToTensor: (PILMask,object) -> encodes
 (PILBase,object) -> encodes ],
 'TfmdDL.__init__.before_batch': None,
 'TfmdDL.__init__.after_batch': (#1) [IntToFloatTensor: (TensorMask,object) -> encodes
 (TensorImage,object) -> encodes (TensorImage,object) -> decodes],
 'TfmdDL.__init__.after_iter': None,
 'TfmdDL.__init__.batch_tfms (not in signature)': [AffineCoordTfm: (TensorBBox,object) -> encodes
  (TensorPoint,object) -> encodes
  (TensorImage,object) -> encodes
  (TensorMask,object) -> encodes ,
  LightingTfm: (TensorImage,object) -> encodes ],
 'TfmdDL.__init__.item_tfms (not in signature)': RandomResizedCrop: (TensorBBox,object) -> encodes
 (TensorPoint,object) -> encodes
 (Image,object) -> encodes }
```

Also we get some print outputs.

```python
@log_args had an issue on DataLoader.__init__ -> got an unexpected keyword argument 'item_tfms'
@log_args had an issue on TfmdDL.__init__ -> got an unexpected keyword argument 'item_tfms'
```

The issue in `37_text.learner` is handled the same way.

I thought it could be helpful in debugging some issues but let me know if you don't want to see it.
Initially I had warnings.warn but it does not look great on jupyter notebooks (print twice) though it's more prominent.