### PR TITLE
feat(log_args): log args before executing function

### DIFF
--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -401,7 +401,6 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
 
     @wraps(f)  # maintain original signature
     def _f(*args, **kwargs):
-        return_val = f(*args, **kwargs)
         f_insp,args_insp = f,args
         xtra_kwargs = {}
         # some functions don't have correct signature (e.g. functions with @delegates such as Datasets.__init__) so we get the one from the class
@@ -420,15 +419,15 @@ def log_args(f=None, *, to_return=False, but=None, but_as=None):
                 func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)
             except:
                 print(f'@log_args had an issue on {f.__qualname__} -> {e}')
-                return return_val
+                return f(*args, **kwargs)
         func_args.apply_defaults()
         log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}
         log = {f'{f.__qualname__}.{k}':v for k,v in log_dict.items() if k not in but}
-        inst = return_val if to_return else args[0]
+        inst = f(*args, **kwargs) if to_return else args[0]
         init_args = getattr(inst, 'init_args', {})
         init_args.update(log)
         setattr(inst, 'init_args', init_args)
-        return return_val
+        return inst if to_return else f(*args, **kwargs)
     return _f
 
 # Cell

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7f993cdb4d90>"
+       "<__main__._t at 0x7f2ffcee7d00>"
       ]
      },
      "execution_count": null,
@@ -1449,7 +1449,6 @@
     "    \n",
     "    @wraps(f)  # maintain original signature\n",
     "    def _f(*args, **kwargs):\n",
-    "        return_val = f(*args, **kwargs)\n",
     "        f_insp,args_insp = f,args\n",
     "        xtra_kwargs = {}\n",
     "        # some functions don't have correct signature (e.g. functions with @delegates such as Datasets.__init__) so we get the one from the class\n",
@@ -1468,15 +1467,15 @@
     "                func_args = inspect.signature(f_insp).bind(*args_insp, **kwargs)\n",
     "            except:\n",
     "                print(f'@log_args had an issue on {f.__qualname__} -> {e}')\n",
-    "                return return_val\n",
+    "                return f(*args, **kwargs)\n",
     "        func_args.apply_defaults()\n",
     "        log_dict = {**func_args.arguments, **{f'{k} (not in signature)':v for k,v in xtra_kwargs.items()}}\n",
     "        log = {f'{f.__qualname__}.{k}':v for k,v in log_dict.items() if k not in but}\n",
-    "        inst = return_val if to_return else args[0]\n",
+    "        inst = f(*args, **kwargs) if to_return else args[0]\n",
     "        init_args = getattr(inst, 'init_args', {})\n",
     "        init_args.update(log)\n",
     "        setattr(inst, 'init_args', init_args)\n",
-    "        return return_val\n",
+    "        return inst if to_return else f(*args, **kwargs)\n",
     "    return _f"
    ]
   },


### PR DESCRIPTION
### Issue

To keep the code minimal and avoid potential errors raised by `log_args`, we would first run decorated function and then log args.

The issue is that when we run `Learner.fit`, the function is ran prior to logging `fit` args so we would be missing those ones (since config is logged while executing this function).

### Solution

When `to_return=False` (default), we log the args prior to running decorated function.

When `to_return=True`, we have to log the args after running the function.

This solves the issue because it seems to be mainly related to `fit` functions and related, which all use `to_return=False`.

*Note*: this is a non-breaking change. It only let us log `fit` related args through callbacks.