### PR TITLE
fix(FixSigMeta): remove self from signature

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -12,11 +12,17 @@ from .imports import *
 defaults = SimpleNamespace()
 
 # Cell
+def _rm_self(sig):
+    sigd = dict(sig.parameters)
+    sigd.pop('self')
+    return sig.replace(parameters=sigd.values())
+
+# Cell
 class FixSigMeta(type):
     "A metaclass that fixes the signature on classes that override __new__"
     def __new__(cls, name, bases, dict):
         res = super().__new__(cls, name, bases, dict)
-        if res.__init__ is not object.__init__: res.__signature__ = inspect.signature(res.__init__)
+        if res.__init__ is not object.__init__: res.__signature__ = _rm_self(inspect.signature(res.__init__))
         return res
 
 # Cell
@@ -140,12 +146,6 @@ def delegates(to=None, keep=False, but=None):
         from_f.__signature__ = sig.replace(parameters=sigd.values())
         return f
     return _f
-
-# Cell
-def _rm_self(sig):
-    sigd = dict(sig.parameters)
-    sigd.pop('self')
-    return sig.replace(parameters=sigd.values())
 
 # Cell
 def funcs_kwargs(cls):

--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -71,12 +71,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#export \n",
+    "def _rm_self(sig):\n",
+    "    sigd = dict(sig.parameters)\n",
+    "    sigd.pop('self')\n",
+    "    return sig.replace(parameters=sigd.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "class FixSigMeta(type):\n",
     "    \"A metaclass that fixes the signature on classes that override __new__\"\n",
     "    def __new__(cls, name, bases, dict):\n",
     "        res = super().__new__(cls, name, bases, dict)\n",
-    "        if res.__init__ is not object.__init__: res.__signature__ = inspect.signature(res.__init__)\n",
+    "        if res.__init__ is not object.__init__: res.__signature__ = _rm_self(inspect.signature(res.__init__))\n",
     "        return res"
    ]
   },
@@ -195,8 +208,7 @@
     "test_eq(t2.foo,2)\n",
     "\n",
     "test_eq(_T.__doc__, \"Testing\")\n",
-    "# TODO: this shouldn't have \"self, \"\n",
-    "test_eq(str(inspect.signature(_T)), '(self, o=None, b=1)')"
+    "test_eq(str(inspect.signature(_T)), '(o=None, b=1)')"
    ]
   },
   {
@@ -559,19 +571,6 @@
     "    def __init__(self, a, b=1, **kwargs): super().__init__(**kwargs)\n",
     "\n",
     "test_sig(Foo, '(a, b=1, c=2)')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#export \n",
-    "def _rm_self(sig):\n",
-    "    sigd = dict(sig.parameters)\n",
-    "    sigd.pop('self')\n",
-    "    return sig.replace(parameters=sigd.values())"
    ]
   },
   {
@@ -2499,5 +2498,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Remove `self` from signature using `FixSigMeta`.

This issue came from a user reporting a `log_args` error on `LabelSmoothingEntropy` (meaning that parameters on this function were not saved).

I noticed that the signature included `self`, then looked at `Module` which uses `PrePostInitMeta`, itself inheriting from `FixSigMeta`. Was tricky to solve but I think this should do it!

In theory there should never be a message from `log_args` unless there's a signature issue.

The only signature issues not shown are when too many parameters are passed because `**kwargs` is typically removed while actually everything is passed. In that case the parameter is named `function.parameter (not in signature)`.