### PR TITLE
CollBase.__getitem__(): listify index like __setitem__().

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -278,7 +278,7 @@ class CollBase:
     "Base class for composing a list of `items`"
     def __init__(self, items): self.items = items
     def __len__(self): return len(self.items)
-    def __getitem__(self, k): return self.items[k]
+    def __getitem__(self, k): return self.items[list(k) if isinstance(k,CollBase) else k]
     def __setitem__(self, k, v): self.items[list(k) if isinstance(k,CollBase) else k] = v
     def __delitem__(self, i): del(self.items[i])
     def __repr__(self): return self.items.__repr__()

--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -1206,7 +1206,7 @@
     "    \"Base class for composing a list of `items`\"\n",
     "    def __init__(self, items): self.items = items\n",
     "    def __len__(self): return len(self.items)\n",
-    "    def __getitem__(self, k): return self.items[k]\n",
+    "    def __getitem__(self, k): return self.items[list(k) if isinstance(k,CollBase) else k]\n",
     "    def __setitem__(self, k, v): self.items[list(k) if isinstance(k,CollBase) else k] = v\n",
     "    def __delitem__(self, i): del(self.items[i])\n",
     "    def __repr__(self): return self.items.__repr__()\n",


### PR DESCRIPTION
(resubmitting, after updating `nbdev`)

Per issue #30.

Only fix `__getitem__()` for now, coz' `__delitem__()` seems more subtle (multiple rows indices? column names?) -- rather keep it simple at the moment.