### PR TITLE
Add classmethod delegation

### DIFF
--- a/docs/foundation.html
+++ b/docs/foundation.html
@@ -19,21 +19,30 @@ description: "Basic functions used in the fastai library"
 -->
 
 <div class="container" id="notebook-container">
-    {% raw %}
         
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="k">import</span> <span class="o">*</span>
-<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="k">import</span> <span class="o">*</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="kn">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="kn">import</span> <span class="o">*</span>
 </pre></div>
 
     </div>
@@ -41,9 +50,15 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Metaclasses">Metaclasses<a class="anchor-link" href="#Metaclasses"> </a></h2>
@@ -62,12 +77,22 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -89,9 +114,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -113,6 +146,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -120,7 +157,7 @@ description: "Basic functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">PrePostInitMeta</span><span class="p">):</span>
     <span class="k">def</span> <span class="nf">__pre_init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span>  <span class="o">=</span> <span class="mi">0</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">0</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">1</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">1</span>
     <span class="k">def</span> <span class="nf">__post_init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">2</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_T</span><span class="p">()</span>
@@ -132,9 +169,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -156,6 +201,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -163,7 +212,7 @@ description: "Basic functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">NewChkMeta</span><span class="p">):</span>
     <span class="s2">&quot;Testing&quot;</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">b</span> <span class="o">=</span> <span class="n">b</span>
 </pre></div>
@@ -173,13 +222,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T2</span><span class="p">():</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_T</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">foo</span><span class="p">,</span><span class="mi">1</span><span class="p">)</span>
@@ -204,9 +257,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -228,6 +289,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -236,7 +301,7 @@ description: "Basic functions used in the fastai library"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">T0</span><span class="p">:</span> <span class="k">pass</span>
 <span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">T0</span><span class="p">,</span> <span class="n">metaclass</span><span class="o">=</span><span class="n">BypassNewMeta</span><span class="p">):</span>
     <span class="n">_bypass_type</span><span class="o">=</span><span class="n">T0</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">x</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">x</span><span class="o">=</span><span class="n">x</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">x</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">x</span><span class="o">=</span><span class="n">x</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">T0</span><span class="p">()</span>
 <span class="n">t</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="mi">1</span>
@@ -253,15 +318,23 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Foundational-functions">Foundational functions<a class="anchor-link" href="#Foundational-functions"> </a></h2>
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -283,9 +356,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -307,6 +388,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -332,6 +417,8 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>cls</code> is a tuple, <code>f</code> is added to all types in the tuple.</p>
@@ -339,6 +426,8 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -359,9 +448,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -383,6 +480,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -403,6 +504,8 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If annotation is a tuple, the function is added to all types in the tuple.</p>
@@ -410,6 +513,8 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -433,9 +538,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -457,6 +570,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -474,9 +591,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -490,9 +615,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -514,6 +647,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -529,9 +666,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -553,6 +698,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -572,9 +721,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -596,6 +753,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -634,17 +795,21 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">BaseFoo</span><span class="p">:</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">e</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">2</span><span class="p">):</span> <span class="k">pass</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">e</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">2</span><span class="p">):</span> <span class="k">pass</span>
 
 <span class="nd">@delegates</span><span class="p">()</span>
 <span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">BaseFoo</span><span class="p">):</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
 
 <span class="n">test_sig</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="s1">&#39;(a, b=1, c=2)&#39;</span><span class="p">)</span>
 </pre></div>
@@ -654,9 +819,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -678,9 +851,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -702,6 +883,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -710,7 +895,7 @@ description: "Basic functions used in the fastai library"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="nd">@funcs_kwargs</span>
 <span class="k">class</span> <span class="nc">T</span><span class="p">:</span>
     <span class="n">_methods</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;b&#39;</span><span class="p">]</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">assert</span> <span class="ow">not</span> <span class="n">kwargs</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">assert</span> <span class="ow">not</span> <span class="n">kwargs</span>
     <span class="k">def</span> <span class="nf">a</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="k">return</span> <span class="mi">1</span>
     <span class="k">def</span> <span class="nf">b</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="k">return</span> <span class="mi">2</span>
     
@@ -728,7 +913,7 @@ description: "Basic functions used in the fastai library"
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">b</span><span class="p">(</span><span class="mi">2</span><span class="p">),</span> <span class="mi">3</span><span class="p">)</span>
 
 <span class="k">class</span> <span class="nc">T2</span><span class="p">(</span><span class="n">T</span><span class="p">):</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">b</span> <span class="o">=</span> <span class="k">lambda</span><span class="p">:</span><span class="mi">3</span><span class="p">)</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">=</span><span class="n">a</span>
 <span class="n">t</span> <span class="o">=</span> <span class="n">T2</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
@@ -746,6 +931,8 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Runtime type checking is handy, so let's make it easy!</p>
@@ -753,6 +940,8 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -772,6 +961,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -785,9 +978,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -809,9 +1010,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -833,6 +1042,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -854,9 +1067,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -878,6 +1099,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -899,6 +1124,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -915,12 +1144,24 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -942,6 +1183,10 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -960,9 +1205,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -984,6 +1237,8 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Inherit from <a href="/foundation#GetAttr"><code>GetAttr</code></a> to have attr access passed down to an instance attribute. 
@@ -1005,6 +1260,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1012,7 +1269,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="c1"># allow all attributes to get passed to `self.default` (by leaving _xtra=None)</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1027,6 +1284,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1034,7 +1295,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_xtra</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;lower&#39;</span><span class="p">]</span> <span class="c1"># specify which attributes get passed to `self.default`</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1050,6 +1311,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1057,7 +1322,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;_data&#39;</span> <span class="c1"># use different component name; `self._data` rather than `self.default`</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">_data</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">_data</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1073,6 +1338,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1080,7 +1349,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;data&#39;</span> <span class="c1"># use a bad component name; i.e. self.data does not exist</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 <span class="c1"># TODO: should we raise an error when we create a new instance ...</span>
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1097,13 +1366,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">B</span><span class="p">:</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="n">A</span><span class="p">()</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="n">A</span><span class="p">()</span>
 </pre></div>
 
     </div>
@@ -1111,6 +1384,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1121,7 +1398,7 @@ This makes it easy to create composites that don't require callers to know about
     <span class="n">wif</span><span class="o">=</span><span class="n">after_iter</span><span class="o">=</span> <span class="n">noops</span>
     <span class="n">_methods</span> <span class="o">=</span> <span class="s1">&#39;wif after_iter&#39;</span><span class="o">.</span><span class="n">split</span><span class="p">()</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;dataset&#39;</span>
-    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">pass</span>
+    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">pass</span>
 </pre></div>
 
     </div>
@@ -1129,6 +1406,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1143,6 +1424,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1160,9 +1445,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1184,6 +1477,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1191,7 +1488,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">:</span>
     <span class="n">f</span> <span class="o">=</span> <span class="s1">&#39;Hi&#39;</span>
-    <span class="k">def</span> <span class="nf">__getattr__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">):</span> <span class="k">return</span> <span class="n">delegate_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">,</span> <span class="s1">&#39;f&#39;</span><span class="p">)</span>
+    <span class="k">def</span> <span class="fm">__getattr__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">):</span> <span class="k">return</span> <span class="n">delegate_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">,</span> <span class="s1">&#39;f&#39;</span><span class="p">)</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">()</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">lower</span><span class="p">(),</span> <span class="s1">&#39;hi&#39;</span><span class="p">)</span>
@@ -1202,12 +1499,24 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1229,6 +1538,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1242,9 +1555,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1266,6 +1587,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1280,6 +1605,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1296,12 +1625,24 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1323,9 +1664,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1347,6 +1696,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1363,9 +1716,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1387,6 +1748,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1400,9 +1765,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1424,9 +1797,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1448,6 +1829,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1464,9 +1849,17 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1488,9 +1881,15 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can create an <a href="/foundation#L"><code>L</code></a> from an existing iterable (e.g. a list, range, etc) and access or modify it with an int list/tuple index, mask, int, or slice. All <code>list</code> methods can also be used with <a href="/foundation#L"><code>L</code></a>.</p>
@@ -1498,6 +1897,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1538,6 +1939,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>There are optimized indexers for arrays, tensors, and DataFrames.</p>
@@ -1545,6 +1948,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1568,6 +1973,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can also modify an <a href="/foundation#L"><code>L</code></a> with <code>append</code>, <code>+</code>, and <code>*</code>.</p>
@@ -1575,6 +1982,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1607,6 +2016,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1624,6 +2037,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>An <a href="/foundation#L"><code>L</code></a> can be constructed from anything iterable, although tensors and arrays will not be iterated over on construction, unless you pass <code>use_list</code> to the constructor.</p>
@@ -1631,6 +2046,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1653,6 +2070,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>match</code> is not <code>None</code> then the created list is same len as <code>match</code>, either by:</p>
@@ -1664,6 +2083,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1679,6 +2100,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you create an <a href="/foundation#L"><code>L</code></a> from an existing <a href="/foundation#L"><code>L</code></a> then you'll get back the original object (since <a href="/foundation#L"><code>L</code></a> uses the <a href="/foundation#NewChkMeta"><code>NewChkMeta</code></a> metaclass).</p>
@@ -1686,6 +2109,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1699,6 +2124,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>An <a href="/foundation#L"><code>L</code></a> is considred equal to a list if they have the same elements. It's never considered equal to a <code>str</code> a <code>set</code> or a <code>dict</code> even if they have the same elements/keys.</p>
@@ -1706,6 +2133,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1722,12 +2151,16 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Methods">Methods<a class="anchor-link" href="#Methods"> </a></h3>
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1749,6 +2182,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1767,6 +2204,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1788,6 +2229,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1804,6 +2249,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1825,6 +2274,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1838,6 +2291,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1859,6 +2316,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1872,6 +2333,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1893,6 +2358,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1922,6 +2391,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1936,6 +2409,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1957,6 +2434,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1970,6 +2451,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1991,6 +2476,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2004,6 +2493,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>f</code> is a string then it is treated as a format string to create the mapping:</p>
@@ -2011,6 +2502,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2024,6 +2517,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>f</code> is a dictionary (or anything supporting <code>__getitem__</code>) then it is indexed to create the mapping:</p>
@@ -2031,6 +2526,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2044,6 +2541,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If the special argument <code>_arg</code> is passed, then that is the kwarg used in the map.</p>
@@ -2051,6 +2550,8 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2065,6 +2566,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2079,6 +2584,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2100,6 +2609,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2114,6 +2627,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2135,6 +2652,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2149,6 +2670,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2164,6 +2689,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2185,6 +2714,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2199,6 +2732,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2220,6 +2757,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2235,6 +2776,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2256,6 +2801,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2269,6 +2818,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2290,6 +2843,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2303,6 +2860,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2324,6 +2885,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2338,6 +2903,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2359,6 +2928,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2372,6 +2945,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2393,6 +2970,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2406,6 +2987,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2427,6 +3012,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2441,6 +3030,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2462,6 +3055,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2475,6 +3072,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2496,6 +3097,10 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
+    {% endraw %}
+
+    {% raw %}
+    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2511,6 +3116,7 @@ This makes it easy to create composites that don't require callers to know about
 
 </div>
     {% endraw %}
+
 </div>
  
 

--- a/docs/foundation.html
+++ b/docs/foundation.html
@@ -19,30 +19,21 @@ description: "Basic functions used in the fastai library"
 -->
 
 <div class="container" id="notebook-container">
+    {% raw %}
         
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="kn">import</span> <span class="o">*</span>
-<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="kn">import</span> <span class="o">*</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="k">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="k">import</span> <span class="o">*</span>
 </pre></div>
 
     </div>
@@ -50,15 +41,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Metaclasses">Metaclasses<a class="anchor-link" href="#Metaclasses"> </a></h2>
@@ -77,22 +62,12 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -114,17 +89,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -146,10 +113,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -157,7 +120,7 @@ description: "Basic functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">PrePostInitMeta</span><span class="p">):</span>
     <span class="k">def</span> <span class="nf">__pre_init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span>  <span class="o">=</span> <span class="mi">0</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">0</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">1</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>  <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">1</span>
     <span class="k">def</span> <span class="nf">__post_init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">+=</span> <span class="mi">1</span><span class="p">;</span> <span class="k">assert</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">2</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_T</span><span class="p">()</span>
@@ -169,17 +132,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -201,10 +156,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -212,7 +163,7 @@ description: "Basic functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">NewChkMeta</span><span class="p">):</span>
     <span class="s2">&quot;Testing&quot;</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">b</span> <span class="o">=</span> <span class="n">b</span>
 </pre></div>
@@ -222,17 +173,13 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T2</span><span class="p">():</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">o</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">foo</span> <span class="o">=</span> <span class="nb">getattr</span><span class="p">(</span><span class="n">o</span><span class="p">,</span><span class="s1">&#39;foo&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_T</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">foo</span><span class="p">,</span><span class="mi">1</span><span class="p">)</span>
@@ -257,17 +204,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -289,10 +228,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -301,7 +236,7 @@ description: "Basic functions used in the fastai library"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">T0</span><span class="p">:</span> <span class="k">pass</span>
 <span class="k">class</span> <span class="nc">_T</span><span class="p">(</span><span class="n">T0</span><span class="p">,</span> <span class="n">metaclass</span><span class="o">=</span><span class="n">BypassNewMeta</span><span class="p">):</span>
     <span class="n">_bypass_type</span><span class="o">=</span><span class="n">T0</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">x</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">x</span><span class="o">=</span><span class="n">x</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">x</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">x</span><span class="o">=</span><span class="n">x</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">T0</span><span class="p">()</span>
 <span class="n">t</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="mi">1</span>
@@ -318,23 +253,15 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Foundational-functions">Foundational functions<a class="anchor-link" href="#Foundational-functions"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -356,17 +283,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -388,10 +307,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -417,8 +332,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>cls</code> is a tuple, <code>f</code> is added to all types in the tuple.</p>
@@ -426,8 +339,6 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -448,17 +359,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -480,10 +383,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -504,8 +403,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If annotation is a tuple, the function is added to all types in the tuple.</p>
@@ -513,8 +410,6 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -538,17 +433,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -570,10 +457,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -591,17 +474,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -615,17 +490,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -647,10 +514,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -666,17 +529,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -698,10 +553,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -721,17 +572,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -753,10 +596,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -776,6 +615,18 @@ description: "Basic functions used in the fastai library"
 <span class="nd">@delegates</span><span class="p">(</span><span class="n">basefoo</span><span class="p">,</span> <span class="n">but</span><span class="o">=</span> <span class="p">[</span><span class="s1">&#39;c&#39;</span><span class="p">])</span>
 <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">pass</span>
 <span class="n">test_sig</span><span class="p">(</span><span class="n">foo</span><span class="p">,</span> <span class="s1">&#39;(a, b=1)&#39;</span><span class="p">)</span>
+
+<span class="k">class</span> <span class="nc">_T</span><span class="p">():</span>
+    <span class="nd">@classmethod</span>
+    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">):</span>
+        <span class="k">pass</span>
+    
+    <span class="nd">@classmethod</span>
+    <span class="nd">@delegates</span><span class="p">(</span><span class="n">foo</span><span class="p">)</span>
+    <span class="k">def</span> <span class="nf">bar</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+        <span class="k">pass</span>
+
+<span class="n">test_sig</span><span class="p">(</span><span class="n">_T</span><span class="o">.</span><span class="n">bar</span><span class="p">,</span> <span class="s1">&#39;(c=3, a=1, b=2)&#39;</span><span class="p">)</span>
 </pre></div>
 
     </div>
@@ -783,21 +634,17 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">BaseFoo</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">e</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">2</span><span class="p">):</span> <span class="k">pass</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">e</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">2</span><span class="p">):</span> <span class="k">pass</span>
 
 <span class="nd">@delegates</span><span class="p">()</span>
 <span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">BaseFoo</span><span class="p">):</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
 
 <span class="n">test_sig</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="s1">&#39;(a, b=1, c=2)&#39;</span><span class="p">)</span>
 </pre></div>
@@ -807,17 +654,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -827,7 +666,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="funcs_kwargs" class="doc_header"><code>funcs_kwargs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L151" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>funcs_kwargs</code>()</p>
+<h4 id="funcs_kwargs" class="doc_header"><code>funcs_kwargs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L152" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>funcs_kwargs</code>()</p>
 </blockquote>
 <p>Replace methods in <code>cls._methods</code> with those from <code>kwargs</code></p>
 
@@ -839,17 +678,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -859,7 +690,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="method" class="doc_header"><code>method</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L167" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>method</code>(<strong><code>f</code></strong>)</p>
+<h4 id="method" class="doc_header"><code>method</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L168" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>method</code>(<strong><code>f</code></strong>)</p>
 </blockquote>
 <p>Mark <code>f</code> as a method</p>
 
@@ -871,10 +702,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -883,7 +710,7 @@ description: "Basic functions used in the fastai library"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="nd">@funcs_kwargs</span>
 <span class="k">class</span> <span class="nc">T</span><span class="p">:</span>
     <span class="n">_methods</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;b&#39;</span><span class="p">]</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">assert</span> <span class="ow">not</span> <span class="n">kwargs</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">assert</span> <span class="ow">not</span> <span class="n">kwargs</span>
     <span class="k">def</span> <span class="nf">a</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="k">return</span> <span class="mi">1</span>
     <span class="k">def</span> <span class="nf">b</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="k">return</span> <span class="mi">2</span>
     
@@ -901,7 +728,7 @@ description: "Basic functions used in the fastai library"
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">b</span><span class="p">(</span><span class="mi">2</span><span class="p">),</span> <span class="mi">3</span><span class="p">)</span>
 
 <span class="k">class</span> <span class="nc">T2</span><span class="p">(</span><span class="n">T</span><span class="p">):</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">b</span> <span class="o">=</span> <span class="k">lambda</span><span class="p">:</span><span class="mi">3</span><span class="p">)</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">a</span><span class="o">=</span><span class="n">a</span>
 <span class="n">t</span> <span class="o">=</span> <span class="n">T2</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
@@ -919,8 +746,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Runtime type checking is handy, so let's make it easy!</p>
@@ -928,8 +753,6 @@ description: "Basic functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -949,10 +772,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -966,17 +785,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -986,7 +797,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="add_docs" class="doc_header"><code>add_docs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L173" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>add_docs</code>(<strong><code>cls_doc</code></strong>=<em><code>None</code></em>, <strong>**<code>docs</code></strong>)</p>
+<h4 id="add_docs" class="doc_header"><code>add_docs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L174" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>add_docs</code>(<strong><code>cls_doc</code></strong>=<em><code>None</code></em>, <strong>**<code>docs</code></strong>)</p>
 </blockquote>
 <p>Copy values from <a href="/foundation#docs"><code>docs</code></a> to <code>cls</code> docstrings, and confirm all public methods are documented</p>
 
@@ -998,17 +809,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1018,7 +821,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="docs" class="doc_header"><code>docs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L187" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>docs</code>()</p>
+<h4 id="docs" class="doc_header"><code>docs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L188" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>docs</code>()</p>
 </blockquote>
 <p>Decorator version of <a href="/foundation#add_docs"><code>add_docs</code></a>, using <code>_docs</code> dict</p>
 
@@ -1030,10 +833,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1055,17 +854,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1075,7 +866,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="custom_dir" class="doc_header"><code>custom_dir</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L193" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>custom_dir</code>(<strong><code>c</code></strong>, <strong><code>add</code></strong>:<code>list</code>)</p>
+<h4 id="custom_dir" class="doc_header"><code>custom_dir</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L194" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>custom_dir</code>(<strong><code>c</code></strong>, <strong><code>add</code></strong>:<code>list</code>)</p>
 </blockquote>
 <p>Implement custom <code>__dir__</code>, adding <code>add</code> to <code>cls</code></p>
 
@@ -1087,10 +878,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1112,10 +899,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1132,24 +915,12 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1159,7 +930,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="bind" class="doc_header"><code>class</code> <code>bind</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L207" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>bind</code>(<strong><code>fn</code></strong>, <strong>*<code>pargs</code></strong>, <strong>**<code>pkwargs</code></strong>)</p>
+<h2 id="bind" class="doc_header"><code>class</code> <code>bind</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L208" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>bind</code>(<strong><code>fn</code></strong>, <strong>*<code>pargs</code></strong>, <strong>**<code>pkwargs</code></strong>)</p>
 </blockquote>
 <p>Same as <code>partial</code>, except you can use <a href="/foundation#arg0"><code>arg0</code></a> <a href="/foundation#arg1"><code>arg1</code></a> etc param placeholders</p>
 
@@ -1171,10 +942,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1193,17 +960,9 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1213,7 +972,7 @@ description: "Basic functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="GetAttr" class="doc_header"><code>class</code> <code>GetAttr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L222" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>GetAttr</code>()</p>
+<h2 id="GetAttr" class="doc_header"><code>class</code> <code>GetAttr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L223" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>GetAttr</code>()</p>
 </blockquote>
 <p>Inherit from this to have all attr accesses in <code>self._xtra</code> passed down to <code>self.default</code></p>
 
@@ -1225,8 +984,6 @@ description: "Basic functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Inherit from <a href="/foundation#GetAttr"><code>GetAttr</code></a> to have attr access passed down to an instance attribute. 
@@ -1248,8 +1005,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1257,7 +1012,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="c1"># allow all attributes to get passed to `self.default` (by leaving _xtra=None)</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1272,10 +1027,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1283,7 +1034,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_xtra</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;lower&#39;</span><span class="p">]</span> <span class="c1"># specify which attributes get passed to `self.default`</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1299,10 +1050,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1310,7 +1057,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;_data&#39;</span> <span class="c1"># use different component name; `self._data` rather than `self.default`</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">_data</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">_data</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1326,10 +1073,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1337,7 +1080,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">(</span><span class="n">GetAttr</span><span class="p">):</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;data&#39;</span> <span class="c1"># use a bad component name; i.e. self.data does not exist</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span><span class="n">a</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">default</span> <span class="o">=</span> <span class="n">a</span>
     <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="n">noop</span>
 <span class="c1"># TODO: should we raise an error when we create a new instance ...</span>
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">(</span><span class="s1">&#39;Hi&#39;</span><span class="p">)</span>
@@ -1354,17 +1097,13 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">B</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="n">A</span><span class="p">()</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">a</span> <span class="o">=</span> <span class="n">A</span><span class="p">()</span>
 </pre></div>
 
     </div>
@@ -1372,10 +1111,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1386,7 +1121,7 @@ This makes it easy to create composites that don't require callers to know about
     <span class="n">wif</span><span class="o">=</span><span class="n">after_iter</span><span class="o">=</span> <span class="n">noops</span>
     <span class="n">_methods</span> <span class="o">=</span> <span class="s1">&#39;wif after_iter&#39;</span><span class="o">.</span><span class="n">split</span><span class="p">()</span>
     <span class="n">_default</span> <span class="o">=</span> <span class="s1">&#39;dataset&#39;</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">pass</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span> <span class="k">pass</span>
 </pre></div>
 
     </div>
@@ -1394,10 +1129,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1412,10 +1143,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1433,17 +1160,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1453,7 +1172,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="delegate_attr" class="doc_header"><code>delegate_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L240" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>delegate_attr</code>(<strong><code>k</code></strong>, <strong><code>to</code></strong>)</p>
+<h4 id="delegate_attr" class="doc_header"><code>delegate_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L241" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>delegate_attr</code>(<strong><code>k</code></strong>, <strong><code>to</code></strong>)</p>
 </blockquote>
 <p>Use in <code>__getattr__</code> to delegate to attr <code>to</code> without inheriting from <a href="/foundation#GetAttr"><code>GetAttr</code></a></p>
 
@@ -1465,10 +1184,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1476,7 +1191,7 @@ This makes it easy to create composites that don't require callers to know about
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_C</span><span class="p">:</span>
     <span class="n">f</span> <span class="o">=</span> <span class="s1">&#39;Hi&#39;</span>
-    <span class="k">def</span> <span class="fm">__getattr__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">):</span> <span class="k">return</span> <span class="n">delegate_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">,</span> <span class="s1">&#39;f&#39;</span><span class="p">)</span>
+    <span class="k">def</span> <span class="nf">__getattr__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">):</span> <span class="k">return</span> <span class="n">delegate_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">k</span><span class="p">,</span> <span class="s1">&#39;f&#39;</span><span class="p">)</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">_C</span><span class="p">()</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">t</span><span class="o">.</span><span class="n">lower</span><span class="p">(),</span> <span class="s1">&#39;hi&#39;</span><span class="p">)</span>
@@ -1487,24 +1202,12 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1514,7 +1217,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="coll_repr" class="doc_header"><code>coll_repr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L257" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>coll_repr</code>(<strong><code>c</code></strong>, <strong><code>max_n</code></strong>=<em><code>10</code></em>)</p>
+<h4 id="coll_repr" class="doc_header"><code>coll_repr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L258" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>coll_repr</code>(<strong><code>c</code></strong>, <strong><code>max_n</code></strong>=<em><code>10</code></em>)</p>
 </blockquote>
 <p>String repr of up to <code>max_n</code> items of (possibly lazy) collection <code>c</code></p>
 
@@ -1526,10 +1229,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1543,17 +1242,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1563,7 +1254,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="mask2idxs" class="doc_header"><code>mask2idxs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L263" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mask2idxs</code>(<strong><code>mask</code></strong>)</p>
+<h4 id="mask2idxs" class="doc_header"><code>mask2idxs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L264" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mask2idxs</code>(<strong><code>mask</code></strong>)</p>
 </blockquote>
 <p>Convert bool mask or index list to index <a href="/foundation#L"><code>L</code></a></p>
 
@@ -1575,10 +1266,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1593,10 +1280,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1613,24 +1296,12 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1640,7 +1311,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="CollBase" class="doc_header"><code>class</code> <code>CollBase</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L277" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>CollBase</code>(<strong><code>items</code></strong>)</p>
+<h2 id="CollBase" class="doc_header"><code>class</code> <code>CollBase</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L278" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>CollBase</code>(<strong><code>items</code></strong>)</p>
 </blockquote>
 <p>Base class for composing a list of <code>items</code></p>
 
@@ -1652,17 +1323,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1672,7 +1335,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="cycle" class="doc_header"><code>cycle</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L288" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>cycle</code>(<strong><code>o</code></strong>)</p>
+<h4 id="cycle" class="doc_header"><code>cycle</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L289" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>cycle</code>(<strong><code>o</code></strong>)</p>
 </blockquote>
 <p>Like <code>itertools.cycle</code> except creates list of <code>None</code>s if <code>o</code> is empty</p>
 
@@ -1684,10 +1347,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1704,17 +1363,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1724,7 +1375,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="zip_cycle" class="doc_header"><code>zip_cycle</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L294" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>zip_cycle</code>(<strong><code>x</code></strong>, <strong>*<code>args</code></strong>)</p>
+<h4 id="zip_cycle" class="doc_header"><code>zip_cycle</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L295" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>zip_cycle</code>(<strong><code>x</code></strong>, <strong>*<code>args</code></strong>)</p>
 </blockquote>
 <p>Like <code>itertools.zip_longest</code> but <a href="/foundation#cycle"><code>cycle</code></a>s through elements of all but first argument</p>
 
@@ -1736,10 +1387,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1753,17 +1400,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1773,7 +1412,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="is_indexer" class="doc_header"><code>is_indexer</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L299" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>is_indexer</code>(<strong><code>idx</code></strong>)</p>
+<h4 id="is_indexer" class="doc_header"><code>is_indexer</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L300" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>is_indexer</code>(<strong><code>idx</code></strong>)</p>
 </blockquote>
 <p>Test whether <code>idx</code> will index a single item in a list</p>
 
@@ -1785,17 +1424,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1805,7 +1436,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="negate_func" class="doc_header"><code>negate_func</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L304" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>negate_func</code>(<strong><code>f</code></strong>)</p>
+<h4 id="negate_func" class="doc_header"><code>negate_func</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L305" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>negate_func</code>(<strong><code>f</code></strong>)</p>
 </blockquote>
 <p>Create new function that negates result of <code>f</code></p>
 
@@ -1817,10 +1448,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1837,17 +1464,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1857,7 +1476,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="L" class="doc_header"><code>class</code> <code>L</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L310" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>L</code>(<strong><code>items</code></strong>=<em><code>None</code></em>, <strong>*<code>rest</code></strong>, <strong><code>use_list</code></strong>=<em><code>False</code></em>, <strong><code>match</code></strong>=<em><code>None</code></em>) :: <a href="/foundation#CollBase"><code>CollBase</code></a></p>
+<h2 id="L" class="doc_header"><code>class</code> <code>L</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L311" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>L</code>(<strong><code>items</code></strong>=<em><code>None</code></em>, <strong>*<code>rest</code></strong>, <strong><code>use_list</code></strong>=<em><code>False</code></em>, <strong><code>match</code></strong>=<em><code>None</code></em>) :: <a href="/foundation#CollBase"><code>CollBase</code></a></p>
 </blockquote>
 <p>Behaves like a list of <code>items</code> but can also index with list of indices or masks</p>
 
@@ -1869,15 +1488,9 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can create an <a href="/foundation#L"><code>L</code></a> from an existing iterable (e.g. a list, range, etc) and access or modify it with an int list/tuple index, mask, int, or slice. All <code>list</code> methods can also be used with <a href="/foundation#L"><code>L</code></a>.</p>
@@ -1885,8 +1498,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1927,8 +1538,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>There are optimized indexers for arrays, tensors, and DataFrames.</p>
@@ -1936,8 +1545,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1961,8 +1568,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can also modify an <a href="/foundation#L"><code>L</code></a> with <code>append</code>, <code>+</code>, and <code>*</code>.</p>
@@ -1970,8 +1575,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2004,10 +1607,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2025,8 +1624,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>An <a href="/foundation#L"><code>L</code></a> can be constructed from anything iterable, although tensors and arrays will not be iterated over on construction, unless you pass <code>use_list</code> to the constructor.</p>
@@ -2034,8 +1631,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2058,8 +1653,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>match</code> is not <code>None</code> then the created list is same len as <code>match</code>, either by:</p>
@@ -2071,8 +1664,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2088,8 +1679,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you create an <a href="/foundation#L"><code>L</code></a> from an existing <a href="/foundation#L"><code>L</code></a> then you'll get back the original object (since <a href="/foundation#L"><code>L</code></a> uses the <a href="/foundation#NewChkMeta"><code>NewChkMeta</code></a> metaclass).</p>
@@ -2097,8 +1686,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2112,8 +1699,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>An <a href="/foundation#L"><code>L</code></a> is considred equal to a list if they have the same elements. It's never considered equal to a <code>str</code> a <code>set</code> or a <code>dict</code> even if they have the same elements/keys.</p>
@@ -2121,8 +1706,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2139,16 +1722,12 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Methods">Methods<a class="anchor-link" href="#Methods"> </a></h3>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2158,7 +1737,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.__getitem__" class="doc_header"><code>L.__getitem__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L327" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.__getitem__</code>(<strong><code>idx</code></strong>)</p>
+<h4 id="L.__getitem__" class="doc_header"><code>L.__getitem__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L328" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.__getitem__</code>(<strong><code>idx</code></strong>)</p>
 </blockquote>
 <p>Retrieve <code>idx</code> (can be list of indices, or mask, or int) items</p>
 
@@ -2170,10 +1749,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2192,10 +1767,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2205,7 +1776,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.__setitem__" class="doc_header"><code>L.__setitem__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L337" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.__setitem__</code>(<strong><code>idx</code></strong>, <strong><code>o</code></strong>)</p>
+<h4 id="L.__setitem__" class="doc_header"><code>L.__setitem__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L338" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.__setitem__</code>(<strong><code>idx</code></strong>, <strong><code>o</code></strong>)</p>
 </blockquote>
 <p>Set <code>idx</code> (can be list of indices, or mask, or int) items to <code>o</code> (which is broadcast if not iterable)</p>
 
@@ -2217,10 +1788,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2237,10 +1804,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2250,7 +1813,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.unique" class="doc_header"><code>L.unique</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L387" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.unique</code>()</p>
+<h4 id="L.unique" class="doc_header"><code>L.unique</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L388" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.unique</code>()</p>
 </blockquote>
 <p>Unique items, in stable order</p>
 
@@ -2262,10 +1825,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2279,10 +1838,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2292,7 +1847,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.val2idx" class="doc_header"><code>L.val2idx</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L389" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.val2idx</code>()</p>
+<h4 id="L.val2idx" class="doc_header"><code>L.val2idx</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L390" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.val2idx</code>()</p>
 </blockquote>
 <p>Dict from value to index</p>
 
@@ -2304,10 +1859,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2321,10 +1872,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2334,7 +1881,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.filter" class="doc_header"><code>L.filter</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L377" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.filter</code>(<strong><code>f</code></strong>, <strong><code>negate</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.filter" class="doc_header"><code>L.filter</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L378" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.filter</code>(<strong><code>f</code></strong>, <strong><code>negate</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> filtered by predicate <code>f</code>, passing <code>args</code> and <code>kwargs</code> to <code>f</code></p>
 
@@ -2346,10 +1893,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2379,10 +1922,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2397,10 +1936,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2410,7 +1945,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.argwhere" class="doc_header"><code>L.argwhere</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L382" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.argwhere</code>(<strong><code>f</code></strong>, <strong><code>negate</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.argwhere" class="doc_header"><code>L.argwhere</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L383" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.argwhere</code>(<strong><code>f</code></strong>, <strong><code>negate</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Like <code>filter</code>, but return indices for matching items</p>
 
@@ -2422,10 +1957,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2439,10 +1970,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2452,7 +1979,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.map" class="doc_header"><code>L.map</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L371" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.map" class="doc_header"><code>L.map</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L372" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> with <code>f</code> applied to all <code>items</code>, passing <code>args</code> and <code>kwargs</code> to <code>f</code></p>
 
@@ -2464,10 +1991,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2481,8 +2004,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>f</code> is a string then it is treated as a format string to create the mapping:</p>
@@ -2490,8 +2011,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2505,8 +2024,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If <code>f</code> is a dictionary (or anything supporting <code>__getitem__</code>) then it is indexed to create the mapping:</p>
@@ -2514,8 +2031,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2529,8 +2044,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If the special argument <code>_arg</code> is passed, then that is the kwarg used in the map.</p>
@@ -2538,8 +2051,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2554,10 +2065,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2572,10 +2079,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2585,7 +2088,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.map_dict" class="doc_header"><code>L.map_dict</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L397" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_dict</code>(<strong><code>f</code></strong>=<em><code>'noop'</code></em>, <strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.map_dict" class="doc_header"><code>L.map_dict</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L398" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_dict</code>(<strong><code>f</code></strong>=<em><code>'noop'</code></em>, <strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Like <code>map</code>, but creates a dict from <code>items</code> to function results</p>
 
@@ -2597,10 +2100,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2615,10 +2114,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2628,7 +2123,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.zip" class="doc_header"><code>L.zip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L399" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.zip</code>(<strong><code>cycled</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="L.zip" class="doc_header"><code>L.zip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L400" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.zip</code>(<strong><code>cycled</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> with <code>zip(*items)</code></p>
 
@@ -2640,10 +2135,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2658,10 +2149,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2677,10 +2164,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2690,7 +2173,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.map_zip" class="doc_header"><code>L.map_zip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L401" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_zip</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.map_zip" class="doc_header"><code>L.map_zip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L402" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_zip</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Combine <code>zip</code> and <code>starmap</code></p>
 
@@ -2702,10 +2185,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2720,10 +2199,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2733,7 +2208,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.zipwith" class="doc_header"><code>L.zipwith</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L400" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.zipwith</code>(<strong>*<code>rest</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="L.zipwith" class="doc_header"><code>L.zipwith</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L401" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.zipwith</code>(<strong>*<code>rest</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> with <code>self</code> zip with each of <code>*rest</code></p>
 
@@ -2745,10 +2220,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2764,10 +2235,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2777,7 +2244,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.map_zipwith" class="doc_header"><code>L.map_zipwith</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L402" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_zipwith</code>(<strong><code>f</code></strong>, <strong>*<code>rest</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="L.map_zipwith" class="doc_header"><code>L.map_zipwith</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L403" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.map_zipwith</code>(<strong><code>f</code></strong>, <strong>*<code>rest</code></strong>, <strong><code>cycled</code></strong>=<em><code>False</code></em>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Combine <code>zipwith</code> and <code>starmap</code></p>
 
@@ -2789,10 +2256,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2806,10 +2269,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2819,7 +2278,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.itemgot" class="doc_header"><code>L.itemgot</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L390" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.itemgot</code>(<strong>*<code>idxs</code></strong>)</p>
+<h4 id="L.itemgot" class="doc_header"><code>L.itemgot</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L391" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.itemgot</code>(<strong>*<code>idxs</code></strong>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> with item <code>idx</code> of all <code>items</code></p>
 
@@ -2831,10 +2290,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2848,10 +2303,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2861,7 +2312,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.attrgot" class="doc_header"><code>L.attrgot</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L395" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.attrgot</code>(<strong><code>k</code></strong>, <strong><code>default</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="L.attrgot" class="doc_header"><code>L.attrgot</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L396" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.attrgot</code>(<strong><code>k</code></strong>, <strong><code>default</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Create new <a href="/foundation#L"><code>L</code></a> with attr <code>k</code> of all <code>items</code></p>
 
@@ -2873,10 +2324,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2891,10 +2338,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2904,7 +2347,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.sorted" class="doc_header"><code>L.sorted</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L357" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.sorted</code>(<strong><code>key</code></strong>=<em><code>None</code></em>, <strong><code>reverse</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="L.sorted" class="doc_header"><code>L.sorted</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L358" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.sorted</code>(<strong><code>key</code></strong>=<em><code>None</code></em>, <strong><code>reverse</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>New <a href="/foundation#L"><code>L</code></a> sorted by <code>key</code>. If key is str then use <code>attrgetter</code>. If key is int then use <code>itemgetter</code></p>
 
@@ -2916,10 +2359,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2933,10 +2372,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2946,7 +2381,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.split" class="doc_header"><code>L.split</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L363" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.split</code>(<strong><code>s</code></strong>, <strong><code>sep</code></strong>=<em><code>None</code></em>, <strong><code>maxsplit</code></strong>=<em><code>-1</code></em>)</p>
+<h4 id="L.split" class="doc_header"><code>L.split</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L364" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.split</code>(<strong><code>s</code></strong>, <strong><code>sep</code></strong>=<em><code>None</code></em>, <strong><code>maxsplit</code></strong>=<em><code>-1</code></em>)</p>
 </blockquote>
 <p>Same as <code>str.split</code>, but returns an <a href="/foundation#L"><code>L</code></a></p>
 
@@ -2958,10 +2393,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2975,10 +2406,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2988,7 +2415,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.range" class="doc_header"><code>L.range</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L366" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.range</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>=<em><code>None</code></em>, <strong><code>step</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="L.range" class="doc_header"><code>L.range</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L367" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.range</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>=<em><code>None</code></em>, <strong><code>step</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Same as <code>range</code>, but returns an <a href="/foundation#L"><code>L</code></a>. Can pass a collection for <code>a</code>, to use <code>len(a)</code></p>
 
@@ -3000,10 +2427,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3018,10 +2441,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3031,7 +2450,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.concat" class="doc_header"><code>L.concat</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L403" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.concat</code>()</p>
+<h4 id="L.concat" class="doc_header"><code>L.concat</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L404" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.concat</code>()</p>
 </blockquote>
 <p>Concatenate all elements of list</p>
 
@@ -3043,10 +2462,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3060,10 +2475,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3073,7 +2484,7 @@ This makes it easy to create composites that don't require callers to know about
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="L.copy" class="doc_header"><code>L.copy</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L328" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.copy</code>()</p>
+<h4 id="L.copy" class="doc_header"><code>L.copy</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/foundation.py#L329" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>L.copy</code>()</p>
 </blockquote>
 <p>Same as <code>list.copy</code>, but returns an <a href="/foundation#L"><code>L</code></a></p>
 
@@ -3085,10 +2496,6 @@ This makes it easy to create composites that don't require callers to know about
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3104,7 +2511,6 @@ This makes it easy to create composites that don't require callers to know about
 
 </div>
     {% endraw %}
-
 </div>
  
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,14 +19,11 @@ description: "Python supercharged for the fastai library"
 -->
 
 <div class="container" id="notebook-container">
-        
     {% raw %}
-    
+        
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Installing">Installing<a class="anchor-link" href="#Installing"> </a></h2>
@@ -90,6 +87,7 @@ pip install -e ".[dev]"</code></pre>
 </div>
 </div>
 </div>
+    {% endraw %}
 </div>
  
 

--- a/docs/transform.html
+++ b/docs/transform.html
@@ -19,32 +19,23 @@ description: "Definition of `Transform` and `Pipeline`"
 -->
 
 <div class="container" id="notebook-container">
+    {% raw %}
         
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">PIL</span> <span class="kn">import</span> <span class="n">Image</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">PIL</span> <span class="k">import</span> <span class="n">Image</span>
 <span class="kn">import</span> <span class="nn">torch</span>
-<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="kn">import</span> <span class="o">*</span>
-<span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="kn">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="k">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="k">import</span> <span class="o">*</span>
 </pre></div>
 
     </div>
@@ -52,8 +43,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The classes here provide functionality for creating a composition of <em>partially reversible functions</em>. By "partially reversible" we mean that a transform can be <code>decode</code>d, creating a form suitable for display. This is not necessarily identical to the original form (e.g. a transform that changes a byte tensor to a float tensor does not recreate a byte tensor when decoded, since that may lose precision, and a float tensor can be displayed already).</p>
@@ -62,43 +51,21 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -120,8 +87,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>A <a href="/transform#Transform"><code>Transform</code></a> is the main building block of the fastai data pipelines. In the most general terms a transform can be any function you want to apply to your data, however the <a href="/transform#Transform"><code>Transform</code></a> class provides several mechanisms that make the process of building them easy and flexible.</p>
@@ -146,8 +111,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -178,8 +141,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/transform#Transform"><code>Transform</code></a> can be used as a decorator, to turn a function into a <a href="/transform#Transform"><code>Transform</code></a>.</p>
@@ -187,8 +148,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -202,10 +161,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -220,10 +175,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -245,8 +196,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can derive from <a href="/transform#Transform"><code>Transform</code></a> and use <code>encodes</code> for your encoding function.</p>
@@ -254,8 +203,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -263,7 +210,7 @@ description: "Definition of `Transform` and `Pipeline`"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">ArrayImage</span><span class="p">(</span><span class="n">ndarray</span><span class="p">):</span>
     <span class="n">_show_args</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;cmap&#39;</span><span class="p">:</span><span class="s1">&#39;viridis&#39;</span><span class="p">}</span>
-    <span class="k">def</span> <span class="fm">__new__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__new__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
         <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">x</span><span class="p">,</span><span class="nb">tuple</span><span class="p">):</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__new__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
         <span class="k">if</span> <span class="n">args</span> <span class="ow">or</span> <span class="n">kwargs</span><span class="p">:</span> <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span><span class="s1">&#39;Unknown array init args&#39;</span><span class="p">)</span>
         <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">x</span><span class="p">,</span><span class="n">ndarray</span><span class="p">):</span> <span class="n">x</span> <span class="o">=</span> <span class="n">array</span><span class="p">(</span><span class="n">x</span><span class="p">)</span>
@@ -284,10 +231,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -333,8 +276,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Without return annotation we get an <a href="/utils#Int"><code>Int</code></a> back since that's what was passed.</p>
@@ -342,8 +283,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -366,8 +305,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Without return annotation we don't cast if we're not a subclass of the input type. If the annotation is a tuple, then any type in the tuple will match.</p>
@@ -375,8 +312,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -398,8 +333,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>With return annotation <code>None</code> we get back whatever Python creates usually.</p>
@@ -407,8 +340,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -425,8 +356,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Since <code>decodes</code> has no return annotation, but <code>encodes</code> created an <a href="/utils#Int"><code>Int</code></a> and we pass that result here to <code>decode</code>, we end up with an <a href="/utils#Int"><code>Int</code></a>.</p>
@@ -434,8 +363,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -454,8 +381,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If the transform has <code>split_idx</code> then it's only applied if <code>split_idx</code> param matches.</p>
@@ -463,8 +388,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -480,8 +403,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Transform takes lists as a whole and is applied to them.</p>
@@ -489,8 +410,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -514,10 +433,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -540,8 +455,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Transforms are applied to each element of a tuple.</p>
@@ -549,8 +462,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -570,17 +481,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -602,10 +505,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -623,10 +522,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -655,10 +550,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -675,8 +566,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Non-type-constrained functions are applied to all elements of a tuple.</p>
@@ -684,8 +573,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -708,8 +595,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Type-constrained functions are applied to only matching elements of a tuple, and return annotations are only applied where matching.</p>
@@ -717,8 +602,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -741,8 +624,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The dispatching over tuples works recursively, by the way:</p>
@@ -750,8 +631,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -769,8 +648,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The same behavior also works with <code>typing</code> module type classes.</p>
@@ -778,8 +655,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -810,23 +685,15 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="ItemTransform">ItemTransform<a class="anchor-link" href="#ItemTransform"> </a></h4>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -848,8 +715,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/transform#ItemTransform"><code>ItemTransform</code></a> is the class to use to opt out of the default behavior of <a href="/transform#Transform"><code>Transform</code></a>.</p>
@@ -857,8 +722,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -878,8 +741,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you pass a special tuple subclass, the usual retain type behavior of <a href="/transform#Transform"><code>Transform</code></a> will keep it:</p>
@@ -887,8 +748,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -904,17 +763,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -936,8 +787,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>This works for any kind of <code>t</code> supporting <code>getattr</code>, so a class or a module.</p>
@@ -945,8 +794,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -967,8 +814,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Transforms are built with multiple-dispatch: a given function can have several methods depending on the type of the object received. This is done directly with the <a href="/dispatch#TypeDispatch"><code>TypeDispatch</code></a> module and type-annotation in <a href="/transform#Transform"><code>Transform</code></a>, but you can also use the following class.</p>
@@ -976,15 +821,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1006,8 +845,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can call the <a href="/transform#Func"><code>Func</code></a> object on any module name or type, even a list of types. It will return the corresponding function (with a default to <code>noop</code> if nothing is found) or list of functions.</p>
@@ -1015,8 +852,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1039,17 +874,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1070,8 +897,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/transform#Sig"><code>Sig</code></a> is just sugar-syntax to create a <a href="/transform#Func"><code>Func</code></a> object more easily with the syntax <a href="/transform#Sig.name(*args, **kwargs"><code>Sig.name(*args, **kwargs)</code></a>).</p>
@@ -1079,8 +904,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1096,17 +919,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1128,10 +943,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1148,10 +959,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1170,10 +977,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1195,10 +998,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1213,17 +1012,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1245,17 +1036,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1277,17 +1060,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1309,17 +1084,9 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1341,10 +1108,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1363,8 +1126,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/transform#Pipeline"><code>Pipeline</code></a> is a wrapper for <code>compose_tfm</code>. You can pass instances of <a href="/transform#Transform"><code>Transform</code></a> or regular functions in <code>funcs</code>, the <a href="/transform#Pipeline"><code>Pipeline</code></a> will wrap them all in <a href="/transform#Transform"><code>Transform</code></a> (and instantiate them if needed) during the initialization. It handles the transform <code>setup</code> by adding them one at a time and calling setup on each, goes through them in order in <code>__call__</code> or <code>decode</code> and can <code>show</code> an object by applying decoding the transforms up until the point it gets an object that knows how to show itself.</p>
@@ -1372,8 +1133,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1389,10 +1148,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1411,10 +1166,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1436,10 +1187,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1459,10 +1206,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1481,8 +1224,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Transforms are available as attributes named with the snake_case version of the names of their types. Attributes in transforms can be directly accessed as attributes of the pipeline.</p>
@@ -1490,8 +1231,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1511,10 +1250,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1532,10 +1267,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1557,10 +1288,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1579,10 +1306,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1598,16 +1321,12 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">PIL</span> <span class="kn">import</span> <span class="n">Image</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">PIL</span> <span class="k">import</span> <span class="n">Image</span>
 
 <span class="k">def</span> <span class="nf">f1</span><span class="p">(</span><span class="n">x</span><span class="p">:</span><span class="n">ArrayImage</span><span class="p">):</span> <span class="k">return</span> <span class="o">-</span><span class="n">x</span>
 <span class="k">def</span> <span class="nf">f2</span><span class="p">(</span><span class="n">x</span><span class="p">):</span> <span class="k">return</span> <span class="n">Image</span><span class="o">.</span><span class="n">open</span><span class="p">(</span><span class="n">x</span><span class="p">)</span><span class="o">.</span><span class="n">resize</span><span class="p">((</span><span class="mi">128</span><span class="p">,</span><span class="mi">128</span><span class="p">))</span>
@@ -1619,10 +1338,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1639,10 +1354,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1676,10 +1387,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1693,10 +1400,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1722,10 +1425,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1743,16 +1442,12 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Methods">Methods<a class="anchor-link" href="#Methods"> </a></h3>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1766,10 +1461,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1791,10 +1482,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1815,10 +1502,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1839,8 +1522,6 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>During the setup, the <a href="/transform#Pipeline"><code>Pipeline</code></a> starts with no transform and adds them one at a time, so that during its setup, each transform gets the items processed up to its point and not after.</p>
@@ -1848,6 +1529,7 @@ description: "Definition of `Transform` and `Pipeline`"
 </div>
 </div>
 </div>
+    {% endraw %}
 </div>
  
 

--- a/docs/utils.html
+++ b/docs/utils.html
@@ -19,31 +19,22 @@ description: "Utility functions used in the fastai library"
 -->
 
 <div class="container" id="notebook-container">
+    {% raw %}
         
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="kn">import</span> <span class="o">*</span>
-<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="kn">import</span> <span class="o">*</span>
-<span class="kn">from</span> <span class="nn">PIL</span> <span class="kn">import</span> <span class="n">Image</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">fastcore.test</span> <span class="k">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">nbdev.showdoc</span> <span class="k">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">PIL</span> <span class="k">import</span> <span class="n">Image</span>
 <span class="kn">import</span> <span class="nn">torch</span>
 </pre></div>
 
@@ -52,23 +43,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Basics">Basics<a class="anchor-link" href="#Basics"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -78,7 +61,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ifnone" class="doc_header"><code>ifnone</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L18" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ifnone</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>)</p>
+<h4 id="ifnone" class="doc_header"><code>ifnone</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L19" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ifnone</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>)</p>
 </blockquote>
 <p><code>b</code> if <code>a</code> is None else <code>a</code></p>
 
@@ -90,8 +73,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Since <code>b if a is None else a</code> is such a common pattern, we wrap it in a function. However, be careful, because python will evaluate <em>both</em> <code>a</code> and <code>b</code> when calling <a href="/utils#ifnone"><code>ifnone</code></a> (which it doesn't do if using the <code>if</code> version directly).</p>
@@ -99,8 +80,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -115,17 +94,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -135,7 +106,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="maybe_attr" class="doc_header"><code>maybe_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L23" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>maybe_attr</code>(<strong><code>o</code></strong>, <strong><code>attr</code></strong>)</p>
+<h4 id="maybe_attr" class="doc_header"><code>maybe_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L24" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>maybe_attr</code>(<strong><code>o</code></strong>, <strong><code>attr</code></strong>)</p>
 </blockquote>
 <p><code>getattr(o,attr,o)</code></p>
 
@@ -147,17 +118,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -167,7 +130,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="basic_repr" class="doc_header"><code>basic_repr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L28" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>basic_repr</code>(<strong><code>flds</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="basic_repr" class="doc_header"><code>basic_repr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L29" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>basic_repr</code>(<strong><code>flds</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 
 </div>
@@ -178,17 +141,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -198,7 +153,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="get_class" class="doc_header"><code>get_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L36" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>get_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
+<h4 id="get_class" class="doc_header"><code>get_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L37" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>get_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
 </blockquote>
 <p>Dynamically create a class, optionally inheriting from <code>sup</code>, containing <code>fld_names</code></p>
 
@@ -210,10 +165,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -238,8 +189,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Most often you'll want to call <a href="/utils#mk_class"><code>mk_class</code></a>, since it adds the class to your module. See <a href="/utils#mk_class"><code>mk_class</code></a> for more details and examples of use (which also apply to <a href="/utils#get_class"><code>get_class</code></a>).</p>
@@ -247,15 +196,9 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -265,7 +208,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="mk_class" class="doc_header"><code>mk_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L61" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mk_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong><code>mod</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
+<h4 id="mk_class" class="doc_header"><code>mk_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L62" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mk_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong><code>mod</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
 </blockquote>
 <p>Create a class using <a href="/utils#get_class"><code>get_class</code></a> and add to the caller's module</p>
 
@@ -277,8 +220,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Any <code>kwargs</code> will be added as class attributes, and <code>sup</code> is an optional (tuple of) base classes.</p>
@@ -286,8 +227,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -304,8 +243,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>A <code>__init__</code> is provided that sets attrs for any <code>kwargs</code>, and for any <code>args</code> (matching by position to fields), along with a <code>__repr__</code> which prints all attrs. The docstring is set to <code>doc</code>. You can pass <code>funcs</code> which will be added as attrs with the function names.</p>
@@ -313,8 +250,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -343,7 +278,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>&lt;__main__._t at 0x7f2ffcee7d00&gt;</pre>
+<pre>&lt;__main__._t at 0x7ff1fa8349d0&gt;</pre>
 </div>
 
 </div>
@@ -352,17 +287,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -372,7 +299,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="wrap_class" class="doc_header"><code>wrap_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L68" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>wrap_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
+<h4 id="wrap_class" class="doc_header"><code>wrap_class</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L69" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>wrap_class</code>(<strong><code>nm</code></strong>, <strong>*<code>fld_names</code></strong>, <strong><code>sup</code></strong>=<em><code>None</code></em>, <strong><code>doc</code></strong>=<em><code>None</code></em>, <strong><code>funcs</code></strong>=<em><code>None</code></em>, <strong>**<code>flds</code></strong>)</p>
 </blockquote>
 <p>Decorator: makes function a method of a new class <code>nm</code> passing parameters to <a href="/utils#mk_class"><code>mk_class</code></a></p>
 
@@ -384,10 +311,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -406,17 +329,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -426,7 +341,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="ignore_exceptions" class="doc_header"><code>class</code> <code>ignore_exceptions</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L76" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ignore_exceptions</code>()</p>
+<h2 id="ignore_exceptions" class="doc_header"><code>class</code> <code>ignore_exceptions</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L77" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ignore_exceptions</code>()</p>
 </blockquote>
 <p>Context manager to ignore exceptions</p>
 
@@ -438,10 +353,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -455,10 +366,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -480,10 +387,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -498,10 +401,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -523,10 +422,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -541,17 +436,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -561,7 +448,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="store_attr" class="doc_header"><code>store_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L82" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>store_attr</code>(<strong><code>nms</code></strong>)</p>
+<h4 id="store_attr" class="doc_header"><code>store_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L83" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>store_attr</code>(<strong><code>nms</code></strong>)</p>
 </blockquote>
 <p>Store params named in comma-separated <code>nms</code> from calling context into attrs in <code>self</code></p>
 
@@ -573,17 +460,13 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">T</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span><span class="n">b</span><span class="p">,</span><span class="n">c</span><span class="p">):</span> <span class="n">store_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="s1">&#39;a,b, c&#39;</span><span class="p">)</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span><span class="n">b</span><span class="p">,</span><span class="n">c</span><span class="p">):</span> <span class="n">store_attr</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="s1">&#39;a,b, c&#39;</span><span class="p">)</span>
 
 <span class="n">t</span> <span class="o">=</span> <span class="n">T</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
 <span class="k">assert</span> <span class="n">t</span><span class="o">.</span><span class="n">a</span><span class="o">==</span><span class="mi">1</span> <span class="ow">and</span> <span class="n">t</span><span class="o">.</span><span class="n">b</span><span class="o">==</span><span class="mi">3</span> <span class="ow">and</span> <span class="n">t</span><span class="o">.</span><span class="n">c</span><span class="o">==</span><span class="mi">2</span>
@@ -594,17 +477,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -614,7 +489,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="attrdict" class="doc_header"><code>attrdict</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L88" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>attrdict</code>(<strong><code>o</code></strong>, <strong>*<code>ks</code></strong>)</p>
+<h4 id="attrdict" class="doc_header"><code>attrdict</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L89" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>attrdict</code>(<strong><code>o</code></strong>, <strong>*<code>ks</code></strong>)</p>
 </blockquote>
 <p>Dict from each <code>k</code> in <code>ks</code> to <code>getattr(o,k)</code></p>
 
@@ -626,10 +501,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -643,17 +514,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -663,7 +526,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="properties" class="doc_header"><code>properties</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L93" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>properties</code>(<strong>*<code>ps</code></strong>)</p>
+<h4 id="properties" class="doc_header"><code>properties</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L94" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>properties</code>(<strong>*<code>ps</code></strong>)</p>
 </blockquote>
 <p>Change attrs in <code>cls</code> with names in <code>ps</code> to properties</p>
 
@@ -675,10 +538,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -698,24 +557,12 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -725,7 +572,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="camel2snake" class="doc_header"><code>camel2snake</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L102" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>camel2snake</code>(<strong><code>name</code></strong>)</p>
+<h4 id="camel2snake" class="doc_header"><code>camel2snake</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L103" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>camel2snake</code>(<strong><code>name</code></strong>)</p>
 </blockquote>
 <p>Convert CamelCase to snake_case</p>
 
@@ -737,10 +584,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -754,17 +597,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -774,7 +609,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="snake2camel" class="doc_header"><code>snake2camel</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L108" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>snake2camel</code>(<strong><code>s</code></strong>)</p>
+<h4 id="snake2camel" class="doc_header"><code>snake2camel</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L109" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>snake2camel</code>(<strong><code>s</code></strong>)</p>
 </blockquote>
 <p>Convert snake_case to CamelCase</p>
 
@@ -786,10 +621,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -803,17 +634,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -823,7 +646,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="class2attr" class="doc_header"><code>class2attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L113" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>class2attr</code>(<strong><code>cls_name</code></strong>)</p>
+<h4 id="class2attr" class="doc_header"><code>class2attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L114" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>class2attr</code>(<strong><code>cls_name</code></strong>)</p>
 </blockquote>
 
 </div>
@@ -834,17 +657,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -854,7 +669,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="hasattrs" class="doc_header"><code>hasattrs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L117" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>hasattrs</code>(<strong><code>o</code></strong>, <strong><code>attrs</code></strong>)</p>
+<h4 id="hasattrs" class="doc_header"><code>hasattrs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L118" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>hasattrs</code>(<strong><code>o</code></strong>, <strong><code>attrs</code></strong>)</p>
 </blockquote>
 <p>Test whether <code>o</code> contains all <code>attrs</code></p>
 
@@ -866,10 +681,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -884,17 +695,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -904,7 +707,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="ShowPrint" class="doc_header"><code>class</code> <code>ShowPrint</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L122" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ShowPrint</code>()</p>
+<h2 id="ShowPrint" class="doc_header"><code>class</code> <code>ShowPrint</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L123" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ShowPrint</code>()</p>
 </blockquote>
 <p>Base class that prints for <code>show</code></p>
 
@@ -916,10 +719,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -929,7 +728,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Int" class="doc_header"><code>class</code> <code>Int</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L126" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Int</code>() :: <code>int</code></p>
+<h2 id="Int" class="doc_header"><code>class</code> <code>Int</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L127" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Int</code>() :: <code>int</code></p>
 </blockquote>
 <p>An extensible <code>int</code></p>
 
@@ -941,10 +740,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -954,7 +749,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Float" class="doc_header"><code>class</code> <code>Float</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L127" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Float</code>(<strong><code>x</code></strong>=<em><code>0</code></em>) :: <code>float</code></p>
+<h2 id="Float" class="doc_header"><code>class</code> <code>Float</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L128" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Float</code>(<strong><code>x</code></strong>=<em><code>0</code></em>) :: <code>float</code></p>
 </blockquote>
 <p>An extensible <code>float</code></p>
 
@@ -966,10 +761,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -979,7 +770,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Str" class="doc_header"><code>class</code> <code>Str</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L128" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Str</code>() :: <code>str</code></p>
+<h2 id="Str" class="doc_header"><code>class</code> <code>Str</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L129" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Str</code>() :: <code>str</code></p>
 </blockquote>
 <p>An extensible <code>str</code></p>
 
@@ -991,23 +782,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Collection-functions">Collection functions<a class="anchor-link" href="#Collection-functions"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1017,7 +800,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="tuplify" class="doc_header"><code>tuplify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L132" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>tuplify</code>(<strong><code>o</code></strong>, <strong><code>use_list</code></strong>=<em><code>False</code></em>, <strong><code>match</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="tuplify" class="doc_header"><code>tuplify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L133" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>tuplify</code>(<strong><code>o</code></strong>, <strong><code>use_list</code></strong>=<em><code>False</code></em>, <strong><code>match</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Make <code>o</code> a tuple</p>
 
@@ -1029,10 +812,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1048,17 +827,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1068,7 +839,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="detuplify" class="doc_header"><code>detuplify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L137" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>detuplify</code>(<strong><code>x</code></strong>)</p>
+<h4 id="detuplify" class="doc_header"><code>detuplify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L138" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>detuplify</code>(<strong><code>x</code></strong>)</p>
 </blockquote>
 <p>If <code>x</code> is a tuple with one thing, extract it</p>
 
@@ -1080,10 +851,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1100,17 +867,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1120,7 +879,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="replicate" class="doc_header"><code>replicate</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L142" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>replicate</code>(<strong><code>item</code></strong>, <strong><code>match</code></strong>)</p>
+<h4 id="replicate" class="doc_header"><code>replicate</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L143" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>replicate</code>(<strong><code>item</code></strong>, <strong><code>match</code></strong>)</p>
 </blockquote>
 <p>Create tuple of <code>item</code> copied <code>len(match)</code> times</p>
 
@@ -1132,10 +891,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1151,17 +906,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1171,7 +918,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="uniqueify" class="doc_header"><code>uniqueify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L147" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>uniqueify</code>(<strong><code>x</code></strong>, <strong><code>sort</code></strong>=<em><code>False</code></em>, <strong><code>bidir</code></strong>=<em><code>False</code></em>, <strong><code>start</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="uniqueify" class="doc_header"><code>uniqueify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L148" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>uniqueify</code>(<strong><code>x</code></strong>, <strong><code>sort</code></strong>=<em><code>False</code></em>, <strong><code>bidir</code></strong>=<em><code>False</code></em>, <strong><code>start</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Return the unique elements in <code>x</code>, optionally <code>sort</code>-ed, optionally return the reverse correspondence.</p>
 
@@ -1183,10 +930,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1208,17 +951,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1228,7 +963,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="setify" class="doc_header"><code>setify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L156" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>setify</code>(<strong><code>o</code></strong>)</p>
+<h4 id="setify" class="doc_header"><code>setify</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L157" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>setify</code>(<strong><code>o</code></strong>)</p>
 </blockquote>
 
 </div>
@@ -1239,10 +974,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1261,17 +992,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1281,7 +1004,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="merge" class="doc_header"><code>merge</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L159" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>merge</code>(<strong>*<code>ds</code></strong>)</p>
+<h4 id="merge" class="doc_header"><code>merge</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L160" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>merge</code>(<strong>*<code>ds</code></strong>)</p>
 </blockquote>
 <p>Merge all dictionaries in <code>ds</code></p>
 
@@ -1293,10 +1016,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1312,17 +1031,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1332,7 +1043,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="is_listy" class="doc_header"><code>is_listy</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L164" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>is_listy</code>(<strong><code>x</code></strong>)</p>
+<h4 id="is_listy" class="doc_header"><code>is_listy</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L165" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>is_listy</code>(<strong><code>x</code></strong>)</p>
 </blockquote>
 <p><code>isinstance(x, (tuple,list,L))</code></p>
 
@@ -1344,10 +1055,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1364,17 +1071,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1384,7 +1083,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="range_of" class="doc_header"><code>range_of</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L169" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>range_of</code>(<strong><code>x</code></strong>)</p>
+<h4 id="range_of" class="doc_header"><code>range_of</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L170" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>range_of</code>(<strong><code>x</code></strong>)</p>
 </blockquote>
 <p>All indices of collection <code>x</code> (i.e. <code>list(range(len(x)))</code>)</p>
 
@@ -1396,10 +1095,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1413,17 +1108,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1433,7 +1120,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="groupby" class="doc_header"><code>groupby</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L174" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>groupby</code>(<strong><code>x</code></strong>, <strong><code>key</code></strong>)</p>
+<h4 id="groupby" class="doc_header"><code>groupby</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L175" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>groupby</code>(<strong><code>x</code></strong>, <strong><code>key</code></strong>)</p>
 </blockquote>
 <p>Like <code>itertools.groupby</code> but doesn't need to be sorted, and isn't lazy</p>
 
@@ -1445,10 +1132,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1462,17 +1145,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1482,7 +1157,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="first" class="doc_header"><code>first</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L181" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>first</code>(<strong><code>x</code></strong>)</p>
+<h4 id="first" class="doc_header"><code>first</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L182" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>first</code>(<strong><code>x</code></strong>)</p>
 </blockquote>
 <p>First element of <code>x</code>, or None if missing</p>
 
@@ -1494,17 +1169,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1514,7 +1181,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="shufflish" class="doc_header"><code>shufflish</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L187" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>shufflish</code>(<strong><code>x</code></strong>, <strong><code>pct</code></strong>=<em><code>0.04</code></em>)</p>
+<h4 id="shufflish" class="doc_header"><code>shufflish</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L188" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>shufflish</code>(<strong><code>x</code></strong>, <strong><code>pct</code></strong>=<em><code>0.04</code></em>)</p>
 </blockquote>
 <p>Randomly relocate items of <code>x</code> up to <code>pct</code> of <code>len(x)</code> from their starting location</p>
 
@@ -1526,10 +1193,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1547,17 +1210,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1567,7 +1222,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="IterLen" class="doc_header"><code>class</code> <code>IterLen</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L193" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>IterLen</code>()</p>
+<h2 id="IterLen" class="doc_header"><code>class</code> <code>IterLen</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L194" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>IterLen</code>()</p>
 </blockquote>
 <p>Base class to add iteration to anything supporting <code>len</code> and <code>__getitem__</code></p>
 
@@ -1579,17 +1234,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1599,7 +1246,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="ReindexCollection" class="doc_header"><code>class</code> <code>ReindexCollection</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L199" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ReindexCollection</code>(<strong><code>coll</code></strong>, <strong><code>idxs</code></strong>=<em><code>None</code></em>, <strong><code>cache</code></strong>=<em><code>None</code></em>, <strong><code>tfm</code></strong>=<em><code>'noop'</code></em>) :: <a href="/foundation#GetAttr"><code>GetAttr</code></a></p>
+<h2 id="ReindexCollection" class="doc_header"><code>class</code> <code>ReindexCollection</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L200" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>ReindexCollection</code>(<strong><code>coll</code></strong>, <strong><code>idxs</code></strong>=<em><code>None</code></em>, <strong><code>cache</code></strong>=<em><code>None</code></em>, <strong><code>tfm</code></strong>=<em><code>'noop'</code></em>) :: <a href="/foundation#GetAttr"><code>GetAttr</code></a></p>
 </blockquote>
 <p>Reindexes collection <code>coll</code> with indices <code>idxs</code> and optional LRU cache of size <code>cache</code></p>
 
@@ -1611,10 +1258,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1639,17 +1282,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1659,7 +1294,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="in_" class="doc_header"><code>in_</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L234" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>in_</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>=<em><code>nan</code></em>)</p>
+<h4 id="in_" class="doc_header"><code>in_</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L235" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>in_</code>(<strong><code>a</code></strong>, <strong><code>b</code></strong>=<em><code>nan</code></em>)</p>
 </blockquote>
 <p>Same as <a href="/utils#operator.in_"><code>operator.in_</code></a>, or returns partial if 1 arg</p>
 
@@ -1671,29 +1306,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The following functions are provided matching the behavior of the equivalent versions in <code>operator</code>: <em>lt gt le ge eq ne add sub mul truediv is_ is_not</em>. In addition one method is added to <code>operator</code>, which is <code>in_(x,a)</code>, which is the same as <code>x in a</code>.</p>
@@ -1701,8 +1322,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1732,8 +1351,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>However, they also have additional functionality: if you only pass one param, they return a partial function that passes that param as the second positional parameter.</p>
@@ -1741,8 +1358,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1772,24 +1387,12 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1799,7 +1402,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Inf" class="doc_header"><code>class</code> <code>Inf</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L254" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Inf</code>()</p>
+<h2 id="Inf" class="doc_header"><code>class</code> <code>Inf</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L255" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Inf</code>()</p>
 </blockquote>
 <p>Infinite lists</p>
 
@@ -1811,8 +1414,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/utils#Inf"><code>Inf</code></a> defines the following properties:</p>
@@ -1826,8 +1427,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1845,17 +1444,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1865,7 +1456,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="true" class="doc_header"><code>true</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L259" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>true</code>(<strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="true" class="doc_header"><code>true</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L260" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>true</code>(<strong>*<code>args</code></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Predicate: always <code>True</code></p>
 
@@ -1877,17 +1468,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1897,7 +1480,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="stop" class="doc_header"><code>stop</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L264" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>stop</code>(<strong><code>e</code></strong>=<em><code>'StopIteration'</code></em>)</p>
+<h4 id="stop" class="doc_header"><code>stop</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L265" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>stop</code>(<strong><code>e</code></strong>=<em><code>'StopIteration'</code></em>)</p>
 </blockquote>
 <p>Raises exception <code>e</code> (by default <code>StopException</code>) even if in an expression</p>
 
@@ -1909,17 +1492,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1929,7 +1504,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gen" class="doc_header"><code>gen</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L269" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>gen</code>(<strong><code>func</code></strong>, <strong><code>seq</code></strong>, <strong><code>cond</code></strong>=<em><code>'true'</code></em>)</p>
+<h4 id="gen" class="doc_header"><code>gen</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L270" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>gen</code>(<strong><code>func</code></strong>, <strong><code>seq</code></strong>, <strong><code>cond</code></strong>=<em><code>'true'</code></em>)</p>
 </blockquote>
 <p>Like <code>(func(o) for o in seq if cond(func(o)))</code> but handles <code>StopIteration</code></p>
 
@@ -1941,10 +1516,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -1963,17 +1534,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -1983,7 +1546,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="chunked" class="doc_header"><code>chunked</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L274" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>chunked</code>(<strong><code>it</code></strong>, <strong><code>cs</code></strong>, <strong><code>drop_last</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="chunked" class="doc_header"><code>chunked</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L275" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>chunked</code>(<strong><code>it</code></strong>, <strong><code>cs</code></strong>, <strong><code>drop_last</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 
 </div>
@@ -1994,10 +1557,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2022,24 +1581,12 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2049,7 +1596,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Tuple" class="doc_header"><code>class</code> <code>Tuple</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L296" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Tuple</code>(<strong><code>x</code></strong>=<em><code>None</code></em>, <strong>*<code>rest</code></strong>) :: <code>tuple</code></p>
+<h2 id="Tuple" class="doc_header"><code>class</code> <code>Tuple</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L297" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Tuple</code>(<strong><code>x</code></strong>=<em><code>None</code></em>, <strong>*<code>rest</code></strong>) :: <code>tuple</code></p>
 </blockquote>
 <p>A <code>tuple</code> with elementwise ops and more friendly <strong>init</strong> behavior</p>
 
@@ -2061,10 +1608,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2095,23 +1638,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Functions-on-functions">Functions on functions<a class="anchor-link" href="#Functions-on-functions"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2121,7 +1656,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="trace" class="doc_header"><code>trace</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L333" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>trace</code>(<strong><code>f</code></strong>)</p>
+<h4 id="trace" class="doc_header"><code>trace</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L334" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>trace</code>(<strong><code>f</code></strong>)</p>
 </blockquote>
 <p>Add <code>set_trace</code> to an existing function <code>f</code></p>
 
@@ -2133,17 +1668,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2153,7 +1680,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="compose" class="doc_header"><code>compose</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L341" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>compose</code>(<strong>*<code>funcs</code></strong>, <strong><code>order</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="compose" class="doc_header"><code>compose</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L342" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>compose</code>(<strong>*<code>funcs</code></strong>, <strong><code>order</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Create a function that composes all functions in <code>funcs</code>, passing along remaining <code>*args</code> and <code>**kwargs</code> to all</p>
 
@@ -2165,10 +1692,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2189,17 +1712,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2209,7 +1724,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="maps" class="doc_header"><code>maps</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L353" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>maps</code>(<strong>*<code>args</code></strong>, <strong><code>retain</code></strong>=<em><code>'noop'</code></em>)</p>
+<h4 id="maps" class="doc_header"><code>maps</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L354" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>maps</code>(<strong>*<code>args</code></strong>, <strong><code>retain</code></strong>=<em><code>'noop'</code></em>)</p>
 </blockquote>
 <p>Like <code>map</code>, except funcs are composed first</p>
 
@@ -2221,10 +1736,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2240,17 +1751,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2260,7 +1763,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="partialler" class="doc_header"><code>partialler</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L360" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>partialler</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong><code>order</code></strong>=<em><code>None</code></em>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="partialler" class="doc_header"><code>partialler</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L361" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>partialler</code>(<strong><code>f</code></strong>, <strong>*<code>args</code></strong>, <strong><code>order</code></strong>=<em><code>None</code></em>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Like <code>functools.partial</code> but also copies over docstring</p>
 
@@ -2272,10 +1775,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2299,17 +1798,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2319,7 +1810,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="mapped" class="doc_header"><code>mapped</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L369" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mapped</code>(<strong><code>f</code></strong>, <strong><code>it</code></strong>)</p>
+<h4 id="mapped" class="doc_header"><code>mapped</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L370" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>mapped</code>(<strong><code>f</code></strong>, <strong><code>it</code></strong>)</p>
 </blockquote>
 <p>map <code>f</code> over <code>it</code>, unless it's not listy, in which case return <code>f(it)</code></p>
 
@@ -2331,10 +1822,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2350,17 +1837,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2370,7 +1849,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="instantiate" class="doc_header"><code>instantiate</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L374" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>instantiate</code>(<strong><code>t</code></strong>)</p>
+<h4 id="instantiate" class="doc_header"><code>instantiate</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L375" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>instantiate</code>(<strong><code>t</code></strong>)</p>
 </blockquote>
 <p>Instantiate <code>t</code> if it's a type, otherwise do nothing</p>
 
@@ -2382,10 +1861,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2400,24 +1875,12 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2427,7 +1890,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="using_attr" class="doc_header"><code>using_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L383" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>using_attr</code>(<strong><code>f</code></strong>, <strong><code>attr</code></strong>)</p>
+<h4 id="using_attr" class="doc_header"><code>using_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L384" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>using_attr</code>(<strong><code>f</code></strong>, <strong><code>attr</code></strong>)</p>
 </blockquote>
 <p>Change function <code>f</code> to operate on <code>attr</code></p>
 
@@ -2439,10 +1902,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2458,10 +1917,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2487,17 +1942,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2507,7 +1954,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="log_args" class="doc_header"><code>log_args</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L388" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>log_args</code>(<strong><code>f</code></strong>=<em><code>None</code></em>, <strong><code>to_return</code></strong>=<em><code>False</code></em>, <strong><code>but</code></strong>=<em><code>None</code></em>, <strong><code>but_as</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="log_args" class="doc_header"><code>log_args</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L389" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>log_args</code>(<strong><code>f</code></strong>=<em><code>None</code></em>, <strong><code>to_return</code></strong>=<em><code>False</code></em>, <strong><code>but</code></strong>=<em><code>None</code></em>, <strong><code>but_as</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Decorator to log function args in 'to.init_args'</p>
 
@@ -2519,10 +1966,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2530,9 +1973,9 @@ description: "Utility functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
     <span class="nd">@log_args</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
-<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="sa">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
+<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="n">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
 </pre></div>
 
     </div>
@@ -2540,8 +1983,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Use <a href="/utils#log_args"><code>log_args</code></a> to save function args in <code>to.init_args</code>. Optional args are:</p>
@@ -2559,8 +2000,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2568,81 +2007,81 @@ description: "Utility functions used in the fastai library"
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
     <span class="nd">@log_args</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
-<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="sa">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
+<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="n">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
 
 <span class="nd">@log_args</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
-<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="sa">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
+<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="n">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
 
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">but</span><span class="o">=</span><span class="s1">&#39;a,c&#39;</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
-<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="sa">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
+<span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="n">f</span><span class="s1">&#39;tst.__init__.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span><span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
 
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
     <span class="k">pass</span>
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">to_return</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="k">def</span> <span class="nf">tst_f</span><span class="p">(</span><span class="n">a</span><span class="p">,</span><span class="n">b</span><span class="p">):</span> <span class="k">return</span> <span class="n">tst</span>
-<span class="n">test_eq</span><span class="p">(</span><span class="n">tst_f</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="sa">f</span><span class="s1">&#39;tst_f.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
+<span class="n">test_eq</span><span class="p">(</span><span class="n">tst_f</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="n">f</span><span class="s1">&#39;tst_f.</span><span class="si">{k}</span><span class="s1">&#39;</span><span class="p">:</span><span class="n">v</span> <span class="k">for</span> <span class="n">k</span><span class="p">,</span><span class="n">v</span> <span class="ow">in</span> <span class="nb">dict</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span><span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">)</span><span class="o">.</span><span class="n">items</span><span class="p">()})</span>
 
 <span class="nd">@log_args</span>
 <span class="nd">@funcs_kwargs</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
     <span class="n">_methods</span><span class="o">=</span><span class="s1">&#39;a&#39;</span><span class="o">.</span><span class="n">split</span><span class="p">()</span>    
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="n">noop</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">[</span><span class="s1">&#39;tst.__init__.a&#39;</span><span class="p">],</span> <span class="n">noop</span><span class="p">)</span>
 
 <span class="k">class</span> <span class="nc">tst_base</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="nd">@log_args</span>
 <span class="nd">@delegates</span><span class="p">(</span><span class="n">tst_base</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">[</span><span class="s1">&#39;tst.__init__.a&#39;</span><span class="p">],</span> <span class="mi">1</span><span class="p">)</span>
 
 <span class="nd">@log_args</span>
 <span class="k">class</span> <span class="nc">tst_parent</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="nd">@log_args</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">(</span><span class="n">tst_parent</span><span class="p">):</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">b</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">b</span><span class="p">):</span>
         <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="n">b</span><span class="p">)</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">(</span><span class="mi">1</span><span class="p">)</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="s1">&#39;tst_parent.__init__.a&#39;</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span> <span class="s1">&#39;tst.__init__.b&#39;</span><span class="p">:</span> <span class="mi">1</span><span class="p">})</span>
 
 <span class="k">class</span> <span class="nc">tst_ref</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="n">test_stdout</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">log_args</span><span class="p">(</span><span class="n">tst</span><span class="p">,</span> <span class="n">but_as</span><span class="o">=</span><span class="n">tst_ref</span><span class="o">.</span><span class="fm">__init__</span><span class="p">),</span> <span class="s1">&#39;@log_args did not find args from but_as while wrapping tst.__init__ in tst_ref.__init__&#39;</span><span class="p">)</span>
 
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">but</span><span class="o">=</span><span class="s1">&#39;a,b&#39;</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst_ref</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">but_as</span><span class="o">=</span><span class="n">tst_ref</span><span class="o">.</span><span class="fm">__init__</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">()</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="s1">&#39;tst.__init__.c&#39;</span><span class="p">:</span> <span class="mi">3</span><span class="p">,</span> <span class="s1">&#39;tst.__init__.d&#39;</span><span class="p">:</span> <span class="mi">4</span><span class="p">})</span>
 
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">but</span><span class="o">=</span><span class="s1">&#39;a,b&#39;</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst_ref</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">,</span> <span class="n">d</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="nd">@log_args</span><span class="p">(</span><span class="n">but</span><span class="o">=</span><span class="s1">&#39;c&#39;</span><span class="p">,</span> <span class="n">but_as</span><span class="o">=</span><span class="n">tst_ref</span><span class="o">.</span><span class="fm">__init__</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">tst</span><span class="p">:</span>
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">2</span><span class="p">,</span> <span class="n">c</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">d</span><span class="o">=</span><span class="mi">4</span><span class="p">):</span>
         <span class="k">pass</span>
 <span class="n">test_eq</span><span class="p">(</span><span class="n">tst</span><span class="p">()</span><span class="o">.</span><span class="n">init_args</span><span class="p">,</span> <span class="p">{</span><span class="s1">&#39;tst.__init__.d&#39;</span><span class="p">:</span> <span class="mi">4</span><span class="p">})</span>
 </pre></div>
@@ -2652,28 +2091,18 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Self">Self<a class="anchor-link" href="#Self"> </a></h3>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>fastai provides a concise way to create lambdas that are calling methods on an object, which is to use <a href="/utils#Self"><code>Self</code></a> (note the capitalization!) <a href="/utils#Self.sum("><code>Self.sum()</code></a>), for instance, is a shortcut for <code>lambda o: o.sum()</code>.</p>
@@ -2681,8 +2110,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2717,23 +2144,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="File-and-network-functions">File and network functions<a class="anchor-link" href="#File-and-network-functions"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2743,7 +2162,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.readlines" class="doc_header"><code>Path.readlines</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L467" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.readlines</code>(<strong><code>hint</code></strong>=<em><code>-1</code></em>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
+<h4 id="Path.readlines" class="doc_header"><code>Path.readlines</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L468" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.readlines</code>(<strong><code>hint</code></strong>=<em><code>-1</code></em>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
 </blockquote>
 <p>Read the content of <code>fname</code></p>
 
@@ -2755,17 +2174,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2775,7 +2186,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.read" class="doc_header"><code>Path.read</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L473" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.read</code>(<strong><code>size</code></strong>=<em><code>-1</code></em>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
+<h4 id="Path.read" class="doc_header"><code>Path.read</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L474" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.read</code>(<strong><code>size</code></strong>=<em><code>-1</code></em>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
 </blockquote>
 <p>Read the content of <code>fname</code></p>
 
@@ -2787,17 +2198,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2807,7 +2210,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.write" class="doc_header"><code>Path.write</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L479" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.write</code>(<strong><code>txt</code></strong>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
+<h4 id="Path.write" class="doc_header"><code>Path.write</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L480" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.write</code>(<strong><code>txt</code></strong>, <strong><code>encoding</code></strong>=<em><code>'utf8'</code></em>)</p>
 </blockquote>
 <p>Write <code>txt</code> to <code>self</code>, creating directories as needed</p>
 
@@ -2819,10 +2222,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2842,17 +2241,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2862,7 +2253,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.save" class="doc_header"><code>Path.save</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L486" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.save</code>(<strong><code>fn</code></strong>:<code>Path</code>, <strong><code>o</code></strong>)</p>
+<h4 id="Path.save" class="doc_header"><code>Path.save</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L487" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.save</code>(<strong><code>fn</code></strong>:<code>Path</code>, <strong><code>o</code></strong>)</p>
 </blockquote>
 <p>Save a pickle file, to a file name or opened file</p>
 
@@ -2874,17 +2265,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2894,7 +2277,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.load" class="doc_header"><code>Path.load</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L494" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.load</code>(<strong><code>fn</code></strong>:<code>Path</code>)</p>
+<h4 id="Path.load" class="doc_header"><code>Path.load</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L495" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.load</code>(<strong><code>fn</code></strong>:<code>Path</code>)</p>
 </blockquote>
 <p>Load a pickle file from a file name or opened file</p>
 
@@ -2906,10 +2289,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2927,17 +2306,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -2947,7 +2318,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.ls" class="doc_header"><code>Path.ls</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L502" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.ls</code>(<strong><code>n_max</code></strong>=<em><code>None</code></em>, <strong><code>file_type</code></strong>=<em><code>None</code></em>, <strong><code>file_exts</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="Path.ls" class="doc_header"><code>Path.ls</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L503" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.ls</code>(<strong><code>n_max</code></strong>=<em><code>None</code></em>, <strong><code>file_type</code></strong>=<em><code>None</code></em>, <strong><code>file_exts</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Contents of path as a list</p>
 
@@ -2959,8 +2330,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>We add an <code>ls()</code> method to <code>pathlib.Path</code> which is simply defined as <code>list(Path.iterdir())</code>, mainly for convenience in REPL environments such as notebooks.</p>
@@ -2968,8 +2337,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -2997,7 +2364,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>PosixPath(&#39;files&#39;)</pre>
+<pre>PosixPath(&#39;00_test.ipynb&#39;)</pre>
 </div>
 
 </div>
@@ -3006,8 +2373,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>You can also pass an optional <code>file_type</code> MIME prefix and/or a list of file extensions.</p>
@@ -3015,8 +2380,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3042,7 +2405,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>(PosixPath(&#39;../fastcore/__init__.py&#39;), PosixPath(&#39;04_transform.ipynb&#39;))</pre>
+<pre>(PosixPath(&#39;../fastcore/dispatch.py&#39;), PosixPath(&#39;00_test.ipynb&#39;))</pre>
 </div>
 
 </div>
@@ -3051,17 +2414,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3071,7 +2426,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Path.__repr__" class="doc_header"><code>Path.__repr__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L513" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.__repr__</code>()</p>
+<h4 id="Path.__repr__" class="doc_header"><code>Path.__repr__</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L514" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Path.__repr__</code>()</p>
 </blockquote>
 <p>Return repr(self).</p>
 
@@ -3083,8 +2438,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>fastai also updates the <code>repr</code> of <code>Path</code> such that, if <code>Path.BASE_PATH</code> is defined, all paths are printed relative to that path (as long as they are contained in <code>Path.BASE_PATH</code>:</p>
@@ -3092,8 +2445,6 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3102,7 +2453,7 @@ description: "Utility functions used in the fastai library"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">t</span> <span class="o">=</span> <span class="n">ipy_files</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">absolute</span><span class="p">()</span>
 <span class="k">try</span><span class="p">:</span>
     <span class="n">Path</span><span class="o">.</span><span class="n">BASE_PATH</span> <span class="o">=</span> <span class="n">t</span><span class="o">.</span><span class="n">parent</span><span class="o">.</span><span class="n">parent</span>
-    <span class="n">test_eq</span><span class="p">(</span><span class="nb">repr</span><span class="p">(</span><span class="n">t</span><span class="p">),</span> <span class="sa">f</span><span class="s2">&quot;Path(&#39;nbs/</span><span class="si">{t.name}</span><span class="s2">&#39;)&quot;</span><span class="p">)</span>
+    <span class="n">test_eq</span><span class="p">(</span><span class="nb">repr</span><span class="p">(</span><span class="n">t</span><span class="p">),</span> <span class="n">f</span><span class="s2">&quot;Path(&#39;nbs/</span><span class="si">{t.name}</span><span class="s2">&#39;)&quot;</span><span class="p">)</span>
 <span class="k">finally</span><span class="p">:</span> <span class="n">Path</span><span class="o">.</span><span class="n">BASE_PATH</span> <span class="o">=</span> <span class="kc">None</span>
 </pre></div>
 
@@ -3111,17 +2462,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3131,7 +2474,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="bunzip" class="doc_header"><code>bunzip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L522" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>bunzip</code>(<strong><code>fn</code></strong>)</p>
+<h4 id="bunzip" class="doc_header"><code>bunzip</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L523" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>bunzip</code>(<strong><code>fn</code></strong>)</p>
 </blockquote>
 <p>bunzip <code>fn</code>, raising exception if output already exists</p>
 
@@ -3143,10 +2486,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3166,17 +2505,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3186,7 +2517,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="join_path_file" class="doc_header"><code>join_path_file</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L532" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>join_path_file</code>(<strong><code>file</code></strong>, <strong><code>path</code></strong>, <strong><code>ext</code></strong>=<em><code>''</code></em>)</p>
+<h4 id="join_path_file" class="doc_header"><code>join_path_file</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L533" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>join_path_file</code>(<strong><code>file</code></strong>, <strong><code>path</code></strong>, <strong><code>ext</code></strong>=<em><code>''</code></em>)</p>
 </blockquote>
 <p>Return <code>path/file</code> if file is a string or a <code>Path</code>, file otherwise</p>
 
@@ -3198,10 +2529,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3220,8 +2547,44 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
+<div class="cell border-box-sizing code_cell rendered">
 
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+
+<div class="output_markdown rendered_html output_subarea ">
+<h4 id="remove_patches_path" class="doc_header"><code>remove_patches_path</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L542" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>remove_patches_path</code>()</p>
+</blockquote>
+
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">with</span> <span class="n">remove_patches_path</span><span class="p">():</span>
+    <span class="k">assert</span> <span class="ow">not</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">Path</span><span class="p">,</span> <span class="s1">&#39;write&#39;</span><span class="p">)</span>
+<span class="k">assert</span> <span class="nb">hasattr</span><span class="p">(</span><span class="n">Path</span><span class="p">,</span> <span class="s1">&#39;write&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Sorting-objects-from-before/after">Sorting objects from before/after<a class="anchor-link" href="#Sorting-objects-from-before/after"> </a></h2>
@@ -3235,15 +2598,9 @@ description: "Utility functions used in the fastai library"
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3253,7 +2610,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="sort_by_run" class="doc_header"><code>sort_by_run</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L552" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>sort_by_run</code>(<strong><code>fs</code></strong>)</p>
+<h4 id="sort_by_run" class="doc_header"><code>sort_by_run</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L565" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>sort_by_run</code>(<strong><code>fs</code></strong>)</p>
 </blockquote>
 
 </div>
@@ -3264,10 +2621,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3304,23 +2657,15 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Other-helpers">Other helpers<a class="anchor-link" href="#Other-helpers"> </a></h2>
 </div>
 </div>
 </div>
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3330,7 +2675,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="PrettyString" class="doc_header"><code>class</code> <code>PrettyString</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L564" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>PrettyString</code>() :: <code>str</code></p>
+<h2 id="PrettyString" class="doc_header"><code>class</code> <code>PrettyString</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L577" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>PrettyString</code>() :: <code>str</code></p>
 </blockquote>
 <p>Little hack to get strings to show properly in Jupyter.</p>
 
@@ -3342,17 +2687,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3362,7 +2699,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="round_multiple" class="doc_header"><code>round_multiple</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L569" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>round_multiple</code>(<strong><code>x</code></strong>, <strong><code>mult</code></strong>, <strong><code>round_down</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="round_multiple" class="doc_header"><code>round_multiple</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L582" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>round_multiple</code>(<strong><code>x</code></strong>, <strong><code>mult</code></strong>, <strong><code>round_down</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Round <code>x</code> to nearest multiple of <code>mult</code></p>
 
@@ -3374,10 +2711,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3396,17 +2729,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3416,7 +2741,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="even_mults" class="doc_header"><code>even_mults</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L576" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>even_mults</code>(<strong><code>start</code></strong>, <strong><code>stop</code></strong>, <strong><code>n</code></strong>)</p>
+<h4 id="even_mults" class="doc_header"><code>even_mults</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L589" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>even_mults</code>(<strong><code>start</code></strong>, <strong><code>stop</code></strong>, <strong><code>n</code></strong>)</p>
 </blockquote>
 <p>Build log-stepped array from <code>start</code> to <a href="/utils#stop"><code>stop</code></a> in <code>n</code> steps.</p>
 
@@ -3428,10 +2753,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3447,17 +2768,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3467,7 +2780,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="num_cpus" class="doc_header"><code>num_cpus</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L584" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>num_cpus</code>()</p>
+<h4 id="num_cpus" class="doc_header"><code>num_cpus</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L597" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>num_cpus</code>()</p>
 </blockquote>
 <p>Get number of cpus</p>
 
@@ -3479,17 +2792,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3499,7 +2804,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="add_props" class="doc_header"><code>add_props</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L592" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>add_props</code>(<strong><code>f</code></strong>, <strong><code>g</code></strong>=<em><code>None</code></em>, <strong><code>n</code></strong>=<em><code>2</code></em>)</p>
+<h4 id="add_props" class="doc_header"><code>add_props</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L605" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>add_props</code>(<strong><code>f</code></strong>, <strong><code>g</code></strong>=<em><code>None</code></em>, <strong><code>n</code></strong>=<em><code>2</code></em>)</p>
 </blockquote>
 <p>Create properties passing each of <code>range(n)</code> to f</p>
 
@@ -3511,10 +2816,6 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -3532,17 +2833,13 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="k">class</span> <span class="nc">_T</span><span class="p">():</span> 
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">v</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">v</span><span class="o">=</span><span class="n">v</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">v</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">v</span><span class="o">=</span><span class="n">v</span>
     <span class="k">def</span> <span class="nf">_set</span><span class="p">(</span><span class="n">i</span><span class="p">,</span> <span class="bp">self</span><span class="p">,</span> <span class="n">v</span><span class="p">):</span> <span class="bp">self</span><span class="o">.</span><span class="n">v</span><span class="p">[</span><span class="n">i</span><span class="p">]</span> <span class="o">=</span> <span class="n">v</span>
     <span class="n">a</span><span class="p">,</span><span class="n">b</span> <span class="o">=</span> <span class="n">add_props</span><span class="p">(</span><span class="k">lambda</span> <span class="n">i</span><span class="p">,</span><span class="n">x</span><span class="p">:</span> <span class="n">x</span><span class="o">.</span><span class="n">v</span><span class="p">[</span><span class="n">i</span><span class="p">],</span> <span class="n">_set</span><span class="p">)</span>
 
@@ -3560,17 +2857,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3580,7 +2869,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="change_attr" class="doc_header"><code>change_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L598" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>change_attr</code>(<strong><code>o</code></strong>, <strong><code>name</code></strong>, <strong><code>new_val</code></strong>)</p>
+<h4 id="change_attr" class="doc_header"><code>change_attr</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L611" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>change_attr</code>(<strong><code>o</code></strong>, <strong><code>name</code></strong>, <strong><code>new_val</code></strong>)</p>
 </blockquote>
 <p>Change the attr <code>name</code> in <code>o</code> with <code>new_val</code> if it exists and return the old value</p>
 
@@ -3592,17 +2881,9 @@ description: "Utility functions used in the fastai library"
 </div>
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
-    {% endraw %}
-
-    {% raw %}
-    
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -3612,7 +2893,7 @@ description: "Utility functions used in the fastai library"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="change_attrs" class="doc_header"><code>change_attrs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L605" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>change_attrs</code>(<strong><code>o</code></strong>, <strong><code>names</code></strong>, <strong><code>new_vals</code></strong>, <strong><code>do</code></strong>=<em><code>None</code></em>)</p>
+<h4 id="change_attrs" class="doc_header"><code>change_attrs</code><a href="https://github.com/fastai/fastcore/tree/master/fastcore/utils.py#L618" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>change_attrs</code>(<strong><code>o</code></strong>, <strong><code>names</code></strong>, <strong><code>new_vals</code></strong>, <strong><code>do</code></strong>=<em><code>None</code></em>)</p>
 </blockquote>
 <p>Change the attr <code>names</code> in <code>o</code> with <code>new_vals</code> if it exists and return the old values</p>
 
@@ -3625,7 +2906,6 @@ description: "Utility functions used in the fastai library"
 
 </div>
     {% endraw %}
-
 </div>
  
 

--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -134,6 +134,7 @@ def delegates(to=None, keep=False, but=None):
         if to is None: to_f,from_f = f.__base__.__init__,f.__init__
         else:          to_f,from_f = to,f
         from_f = getattr(from_f,'__func__',from_f)
+        to_f = getattr(to_f,'__func__',to_f)
         if hasattr(from_f,'__delwrap__'): return f
         sig = inspect.signature(from_f)
         sigd = dict(sig.parameters)

--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -521,6 +521,7 @@
     "        if to is None: to_f,from_f = f.__base__.__init__,f.__init__\n",
     "        else:          to_f,from_f = to,f\n",
     "        from_f = getattr(from_f,'__func__',from_f)\n",
+    "        to_f = getattr(to_f,'__func__',to_f)\n",
     "        if hasattr(from_f,'__delwrap__'): return f\n",
     "        sig = inspect.signature(from_f)\n",
     "        sigd = dict(sig.parameters)\n",
@@ -554,7 +555,19 @@
     "\n",
     "@delegates(basefoo, but= ['c'])\n",
     "def foo(a, b=1, **kwargs): pass\n",
-    "test_sig(foo, '(a, b=1)')"
+    "test_sig(foo, '(a, b=1)')\n",
+    "\n",
+    "class _T():\n",
+    "    @classmethod\n",
+    "    def foo(cls, a=1, b=2):\n",
+    "        pass\n",
+    "    \n",
+    "    @classmethod\n",
+    "    @delegates(foo)\n",
+    "    def bar(cls, c=3, **kwargs):\n",
+    "        pass\n",
+    "\n",
+    "test_sig(_T.bar, '(c=3, a=1, b=2)')"
    ]
   },
   {


### PR DESCRIPTION
I ran into a problem where I wanted to be able to delegate the kwargs of one class method within a class to a different classmethod within the same class.

This was an issue because inspect.signature would not work on a classmethod because it is not callable. All I needed to do was add a line that made the inspection of to_f to be the same as from_f.

Looks like some extra uncommited documentation additions creeped into this PR as well.