### PR TITLE
updated store_attr so nms can be None

### DIFF
--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -80,10 +80,13 @@ class ignore_exceptions:
     def __exit__(self, *args): return True
 
 # Cell
-def store_attr(self, nms):
+def store_attr(self, nms=None):
     "Store params named in comma-separated `nms` from calling context into attrs in `self`"
     mod = inspect.currentframe().f_back.f_locals
-    for n in re.split(', *', nms): setattr(self,n,mod[n])
+    _mod={k:v for k,v in mod.items() if k not in ['self','args','kwargs']}
+    if 'kwargs' in mod: _mod.update(mod['kwargs'])
+    _nms=re.split(', *', nms) if nms else [k for k in _mod.keys() if k!='self']
+    for n in _nms: setattr(self,n,_mod[n])
 
 # Cell
 def attrdict(o, *ks):

--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -83,10 +83,9 @@ class ignore_exceptions:
 def store_attr(self, nms=None):
     "Store params named in comma-separated `nms` from calling context into attrs in `self`"
     mod = inspect.currentframe().f_back.f_locals
-    _mod={k:v for k,v in mod.items() if k not in ['self','args','kwargs']}
-    if 'kwargs' in mod: _mod.update(mod['kwargs'])
-    _nms=re.split(', *', nms) if nms else [k for k in _mod.keys() if k!='self']
-    for n in _nms: setattr(self,n,_mod[n])
+    if 'kwargs' in mod: mod.update(mod['kwargs'])
+    nms = re.split(', *', nms) if nms else [k for k in mod.keys() if k not in ['self','args','kwargs']]
+    for n in nms: setattr(self,n,mod[n])
 
 # Cell
 def attrdict(o, *ks):

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7ff1fa8349d0>"
+       "<__main__._t at 0x7fb5d37f5290>"
       ]
      },
      "execution_count": null,
@@ -362,10 +362,21 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def store_attr(self, nms):\n",
+    "def store_attr(self, nms=None):\n",
     "    \"Store params named in comma-separated `nms` from calling context into attrs in `self`\"\n",
     "    mod = inspect.currentframe().f_back.f_locals\n",
-    "    for n in re.split(', *', nms): setattr(self,n,mod[n])"
+    "    _mod={k:v for k,v in mod.items() if k not in ['self','args','kwargs']}\n",
+    "    if 'kwargs' in mod: _mod.update(mod['kwargs'])\n",
+    "    _nms=re.split(', *', nms) if nms else [k for k in _mod.keys() if k!='self']\n",
+    "    for n in _nms: setattr(self,n,_mod[n])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function can be used in 2 different ways.\n",
+    "1. By passing the names of parameters to store in `nms`"
    ]
   },
   {
@@ -378,7 +389,41 @@
     "    def __init__(self, a,b,c): store_attr(self, 'a,b, c')\n",
     "\n",
     "t = T(1,c=2,b=3)\n",
-    "assert t.a==1 and t.b==3 and t.c==2"
+    "assert t.a==1 and t.b==3 and t.c==2 and not hasattr(t,'d')\n",
+    "\n",
+    "class T:\n",
+    "    def __init__(self, a,d=4,*args,**kwargs): store_attr(self, 'a,b, c')\n",
+    "\n",
+    "t = T(1,c=2,b=3)\n",
+    "assert t.a==1 and t.b==3 and t.c==2 and not hasattr(t,'d')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2. By not passing anything for `nms`\n",
+    "    - In which case, `store_attr` will store all parameters except for \"self\", \"args\" and \"kwargs\"\n",
+    "    - `store_attr` *won't* store a parameter called \"kwargs\" but *will* try to store the contents of \"kwargs\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class T:\n",
+    "    def __init__(self, a,b,c): store_attr(self)\n",
+    "\n",
+    "t = T(1,c=2,b=3)\n",
+    "assert t.a==1 and t.b==3 and t.c==2 and not hasattr(t,'args')\n",
+    "\n",
+    "class T:\n",
+    "    def __init__(self, a,d=4,*args,**kwargs): store_attr(self)\n",
+    "\n",
+    "t = T(1,c=2,b=3)\n",
+    "assert t.a==1 and t.b==3 and t.c==2 and hasattr(t,'d') and not hasattr(t,'kwargs')"
    ]
   },
   {
@@ -1827,7 +1872,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('00_test.ipynb')"
+       "PosixPath('index.ipynb')"
       ]
      },
      "execution_count": null,
@@ -1861,7 +1906,7 @@
     {
      "data": {
       "text/plain": [
-       "(PosixPath('../fastcore/dispatch.py'), PosixPath('00_test.ipynb'))"
+       "(PosixPath('../fastcore/imports.py'), PosixPath('index.ipynb'))"
       ]
      },
      "execution_count": null,

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -212,7 +212,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7fb5d37f5290>"
+       "<__main__._t at 0x7f97df37d090>"
       ]
      },
      "execution_count": null,
@@ -365,10 +365,9 @@
     "def store_attr(self, nms=None):\n",
     "    \"Store params named in comma-separated `nms` from calling context into attrs in `self`\"\n",
     "    mod = inspect.currentframe().f_back.f_locals\n",
-    "    _mod={k:v for k,v in mod.items() if k not in ['self','args','kwargs']}\n",
-    "    if 'kwargs' in mod: _mod.update(mod['kwargs'])\n",
-    "    _nms=re.split(', *', nms) if nms else [k for k in _mod.keys() if k!='self']\n",
-    "    for n in _nms: setattr(self,n,_mod[n])"
+    "    if 'kwargs' in mod: mod.update(mod['kwargs'])\n",
+    "    nms = re.split(', *', nms) if nms else [k for k in mod.keys() if k not in ['self','args','kwargs']]\n",
+    "    for n in nms: setattr(self,n,mod[n])"
    ]
   },
   {
@@ -389,7 +388,7 @@
     "    def __init__(self, a,b,c): store_attr(self, 'a,b, c')\n",
     "\n",
     "t = T(1,c=2,b=3)\n",
-    "assert t.a==1 and t.b==3 and t.c==2 and not hasattr(t,'d')\n",
+    "assert t.a==1 and t.b==3 and t.c==2\n",
     "\n",
     "class T:\n",
     "    def __init__(self, a,d=4,*args,**kwargs): store_attr(self, 'a,b, c')\n",
@@ -402,9 +401,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#hide\n",
+    "\n",
+    "`'args'` and `'kwargs'` can be used in `nms` as long as `'kwargs'` is a `dict`.\n",
+    "\n",
+    "Hopefully it's safe to assume people won't stray too far from convention when naming their parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "class T:\n",
+    "    def __init__(self, args, kwargs): store_attr(self, 'args, kwargs')\n",
+    "\n",
+    "t = T(1,{'d':4})\n",
+    "assert t.args==1 and t.kwargs=={'d':4}\n",
+    "\n",
+    "class T:\n",
+    "    def __init__(self, a,*args,**kwargs): store_attr(self, 'a,args,kwargs')\n",
+    "\n",
+    "t = T(1,2,None,d=4)\n",
+    "assert t.a==1 and t.args==(2,None) and t.kwargs=={'d':4}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "2. By not passing anything for `nms`\n",
-    "    - In which case, `store_attr` will store all parameters except for \"self\", \"args\" and \"kwargs\"\n",
-    "    - `store_attr` *won't* store a parameter called \"kwargs\" but *will* try to store the contents of \"kwargs\""
+    "    - In which case, `store_attr` will store all parameters except for `'self'`, `'args'` and `'kwargs'`\n",
+    "    - `store_attr` *won't* store a parameter called `'kwargs'` but *will* store the contents of `'kwargs'`"
    ]
   },
   {


### PR DESCRIPTION
Hopefully this will help save a little typing allowing things like
```python
class Interpretation():
    "Interpretation base class, can be inherited for task specific Interpretation classes"
    def __init__(self, dl, inputs, preds, targs, decoded, losses):
        store_attr(self, "dl,inputs,preds,targs,decoded,losses")
```
to be written as
```python
class Interpretation():
    "Interpretation base class, can be inherited for task specific Interpretation classes"
    def __init__(self, dl, inputs, preds, targs, decoded, losses):
        store_attr(self)
```
Hope it also helps that store_attr can now pick up parameters from kwargs too.