### PR TITLE
Add Integration tests for fastai into CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,21 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  fastcore:
     runs-on: ubuntu-latest
+    container: fastdotai/fastai #this is defined here: https://github.com/fastai/docker-containers/blob/master/fastai-build/Dockerfile
+    env:
+      download: "true"
+      caching: "true"
+    strategy:
+      matrix:
+        nb: ['[0-2]','[3-5]','[6-9]']
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.6'
-        architecture: 'x64'
+    - uses: actions/checkout@v2
     - name: Install the library
       run: |
-        pip install wheel
-        pip install nbdev jupyter
-        pip install -e .[dev]
+        pip install -U nbdev
+        pip install -Ue .[dev]
     - name: Read all notebooks
       run: |
         nbdev_read_nbs
@@ -29,6 +31,36 @@ jobs:
     - name: Check if there is no diff library/notebooks
       run: |
         if [ -n "$(nbdev_diff_nbs)" ]; then echo -e "!!! Detected difference between the notebooks and the library"; false; fi
-    - name: Run tests
+    - name: Run fastcore tests
       run: |
         nbdev_test_nbs
+        
+    - name: clone fastai
+      uses: actions/checkout@v2
+      with:
+        repo: 'fastai/fastai'
+    
+    - name: Install fastai
+      run: |
+        pip install -Ue .
+        
+    - name: check for cache hit
+      uses: actions/cache@v2
+      if: env.caching == 'true'
+      id: cache
+      with:
+        path: ~/.fastai/data
+        key: 'fastai-test-data-v1'
+
+    - name: download data
+      if: env.download == 'true' && steps.cache.outputs.cache-hit != 'true'
+      run: |
+        ipython /workspace/download_testdata.py
+        mkdir -p $HOME/.fastai/data
+        find $HOME/.fastai/archive/ -name "*.tgz" -exec tar -xzvf {} -C $HOME/.fastai/data \;
+          
+    - name: Test fastai notebooks - batch ${{matrix.nb}}
+      run: |
+        nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
+
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches: 
+      - master
 jobs:
   fastcore:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,6 @@ jobs:
     - name: Test fastai notebooks
       run: |
         cd fastai
-        nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/*.ipynb"
+        nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,21 +36,35 @@ jobs:
     - name: Run fastcore tests
       run: |
         nbdev_test_nbs
+
+  test-fastai-notebooks:
+    needs: fastcore
+    container: fastdotai/fastai
+    runs-on: ubuntu-latest
+    env:
+      download: "true"
+      caching: "true"
+    strategy:
+      matrix:
+        nb: ['[0-2]','[3-5]','[6-9]']
+    steps:
+    - name: clone this branch [fastcore]
+      uses: actions/checkout@v2
+      with:
+        path: fastcore/
         
     - name: clone fastai
       uses: actions/checkout@v2
       with:
         repository: 'fastai/fastai'
- 
-    - name: check dir
+        path: fastai
+
+    - name: Install libraries
       run: |
-        pwd
-        ls
-    
-    - name: Install fastai
-      run: |
-        pip install -Ue .
-        
+        pip install -U nbdev
+         pip install -Ue fastai/
+        pip install -Ue .[dev] fastcore/     
+   
     - name: check for cache hit
       uses: actions/cache@v2
       if: env.caching == 'true'
@@ -68,6 +82,7 @@ jobs:
           
     - name: Test fastai notebooks
       run: |
+        cd fastai
         nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/*.ipynb"
 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,7 @@ jobs:
       run: |
         nbdev_test_nbs
 
-  test-fastai-notebooks:
-    needs: fastcore
+  fastai-integration-test:
     container: fastdotai/fastai
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         repo: 'fastai/fastai'
+ 
+    - name: check dir
+      run: |
+        pwd
+        ls
     
     - name: Install fastai
       run: |
@@ -53,11 +58,6 @@ jobs:
       with:
         path: ~/.fastai/data
         key: 'fastai-test-data-v1'
-    
-    - name: check dir
-      run: |
-        pwd
-        ls
 
     - name: download data
       if: env.download == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,11 @@ jobs:
         repository: 'fastai/fastai'
         path: fastai
 
+    - name: see directories
+      run: |
+        pwd
+        ls
+        
     - name: Install libraries
       run: |
         pip install -U nbdev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       id: cache
       with:
         path: ~/.fastai/data
-        key: 'fastai-test-data-v1'
+        key: 'fastai-test-data-v2'
 
     - name: download data
       if: env.download == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     - name: clone fastai
       uses: actions/checkout@v2
       with:
-        repo: 'fastai/fastai'
+        repository: 'fastai/fastai'
  
     - name: check dir
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,11 @@ jobs:
       with:
         path: ~/.fastai/data
         key: 'fastai-test-data-v1'
+    
+    - name: check dir
+      run: |
+        pwd
+        ls
 
     - name: download data
       if: env.download == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,9 +67,10 @@ jobs:
     - name: Install libraries
       run: |
         pip install -U nbdev
-         pip install -Ue fastai/
-        pip install -Ue .[dev] fastcore/     
-   
+        cd fastai && pip install -Ue .
+        cd fastcore && pip install -Ue .[dev]
+        cd ~     
+    
     - name: check for cache hit
       uses: actions/cache@v2
       if: env.caching == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   fastcore:
     runs-on: ubuntu-latest
-    container: fastdotai/fastai #this is defined here: https://github.com/fastai/docker-containers/blob/master/fastai-build/Dockerfile
+    container: fastdotai/fastai #defined here: https://github.com/fastai/docker-containers/blob/master/fastai-build/Dockerfile
     env:
       download: "true"
       caching: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,7 @@ jobs:
     env:
       download: "true"
       caching: "true"
-    strategy:
-      matrix:
-        nb: ['[0-2]','[3-5]','[6-9]']
+
     steps:
     - uses: actions/checkout@v2
     - name: Install the library
@@ -63,8 +61,8 @@ jobs:
         mkdir -p $HOME/.fastai/data
         find $HOME/.fastai/archive/ -name "*.tgz" -exec tar -xzvf {} -C $HOME/.fastai/data \;
           
-    - name: Test fastai notebooks - batch ${{matrix.nb}}
+    - name: Test fastai notebooks
       run: |
-        nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
+        nbdev_test_nbs --flags '' --n_workers 3 --pause 0.5 --fname "nbs/*.ipynb"
 
         


### PR DESCRIPTION
These tests also check to make sure that any changes to fastcore do not break anything in fastai

@jph00 ready for review - the length of CI, however, increases from 2 to 4 minutes

We could alternatively make these integration tests nightly