### PR TITLE
feat(store_attr): handle functions vs methods

### DIFF
--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -98,7 +98,7 @@ def store_attr(names=None, self=None, but=None, **attrs):
     if not hasattr(self, '__stored_args__'): self.__stored_args__ = {}
     if attrs: return _store_attr(self, **attrs)
 
-    ns = re.split(', *', names) if names else args[1:]
+    ns = re.split(', *', names) if names else args[1:] if args[0] == 'self' else args
     _store_attr(self, **{n:fr.f_locals[n] for n in ns if n not in L(but)})
 
 # Cell

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,16 +284,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<__main__._t at 0x7f8ef8a7ce10>"
+       "<__main__._t at 0x7f9d8dd131c0>"
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +507,7 @@
     "    if not hasattr(self, '__stored_args__'): self.__stored_args__ = {}\n",
     "    if attrs: return _store_attr(self, **attrs)\n",
     "    \n",
-    "    ns = re.split(', *', names) if names else args[1:]\n",
+    "    ns = re.split(', *', names) if names else args[1:] if args[0] == 'self' else args\n",
     "    _store_attr(self, **{n:fr.f_locals[n] for n in ns if n not in L(but)})"
    ]
   },
@@ -520,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,12 +718,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also pass keywords to `store_attr`, which is identical to setting the attrs directly, but also stores them in `__stored_args__`."
+    "You can also pass keywords to `store_attr`, which is identical to setting the attrs directly, and also stores them in `__stored_args__`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,8 +735,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use `store_attr` inside functions."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class T:\n",
+    "    pass\n",
+    "\n",
+    "def create_T(a, b):\n",
+    "    t = T()\n",
+    "    store_attr(self=t)\n",
+    "    return t\n",
+    "\n",
+    "t = create_T(a=1, b=2)\n",
+    "assert t.a==1 and t.b==2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -812,7 +837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,7 +847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -855,7 +880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -877,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -889,7 +914,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -935,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -998,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1010,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1021,7 +1046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1033,7 +1058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1057,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1068,7 +1093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1151,7 +1176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1188,7 +1213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,7 +1236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1220,7 +1245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1266,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1279,7 +1304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1299,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1312,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1342,7 +1367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -1386,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -1395,7 +1420,7 @@
        "['e', 'd', 'c', 'b', 'a']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1414,7 +1439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -1440,7 +1465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -1449,7 +1474,7 @@
        "['e', 'd', 'c', 'b', 'a']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1476,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -1485,7 +1510,7 @@
        "CacheInfo(hits=1, misses=1, maxsize=2, currsize=1)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1508,7 +1533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -1534,7 +1559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -1543,7 +1568,7 @@
        "CacheInfo(hits=0, misses=0, maxsize=2, currsize=0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1560,7 +1585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -1593,16 +1618,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['b', 'c', 'f', 'g', 'h', 'a', 'd', 'e']"
+       "['e', 'a', 'd', 'g', 'c', 'h', 'b', 'f']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1622,7 +1647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1642,7 +1667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1654,7 +1679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1684,7 +1709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1728,7 +1753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -1782,7 +1807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1800,7 +1825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -1826,7 +1851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1837,7 +1862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [
     {
@@ -1863,7 +1888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1885,7 +1910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1904,7 +1929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1923,7 +1948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1944,7 +1969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1963,7 +1988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1975,7 +2000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -2013,7 +2038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2039,7 +2064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2058,7 +2083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2072,7 +2097,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2082,7 +2107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2092,7 +2117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2117,7 +2142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -2126,7 +2151,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2144,7 +2169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -2153,7 +2178,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2164,7 +2189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2176,7 +2201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2188,7 +2213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2200,7 +2225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2223,7 +2248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2235,7 +2260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2249,7 +2274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2274,7 +2299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2303,7 +2328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2363,7 +2388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2382,7 +2407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2398,7 +2423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2412,7 +2437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2423,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2439,7 +2464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2458,7 +2483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2470,7 +2495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2481,7 +2506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2493,7 +2518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2503,7 +2528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2513,7 +2538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2525,7 +2550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2536,7 +2561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2590,7 +2615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2619,7 +2644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2653,7 +2678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2714,7 +2739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2748,7 +2773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2762,7 +2787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2781,7 +2806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2829,7 +2854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2842,7 +2867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2855,7 +2880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2869,7 +2894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2884,7 +2909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2899,7 +2924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2914,7 +2939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2927,7 +2952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 154,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2952,16 +2977,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Path('.ipynb_checkpoints')"
+       "Path('files')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2986,16 +3011,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Path('../fastcore/utils.py'), Path('04_transform.ipynb'))"
+       "(Path('../fastcore/__init__.py'), Path('04_transform.ipynb'))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3011,7 +3036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3023,7 +3048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3046,7 +3071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3059,7 +3084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3086,7 +3111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3106,7 +3131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3123,7 +3148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3138,7 +3163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3152,7 +3177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3166,7 +3191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3178,7 +3203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3204,7 +3229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3236,7 +3261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 169,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3275,7 +3300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3287,7 +3312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 171,
    "metadata": {},
    "outputs": [
     {
@@ -3320,7 +3345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 172,
    "metadata": {},
    "outputs": [
     {
@@ -3329,7 +3354,7 @@
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 172,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3348,7 +3373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [
     {
@@ -3360,7 +3385,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": null,
+     "execution_count": 173,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3371,7 +3396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 174,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3385,7 +3410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3399,7 +3424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3414,7 +3439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3425,7 +3450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3440,16 +3465,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "64"
+       "4"
       ]
      },
-     "execution_count": null,
+     "execution_count": 179,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3460,7 +3485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3473,7 +3498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3486,7 +3511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3506,7 +3531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3516,7 +3541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3530,7 +3555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [
     {
@@ -3563,7 +3588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3576,7 +3601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3604,7 +3629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3622,7 +3647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3647,7 +3672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [
     {
@@ -3655,7 +3680,7 @@
       "text/markdown": [
        "<h4 id=\"ProcessPoolExecutor\" class=\"doc_header\"><code>class</code> <code>ProcessPoolExecutor</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>ProcessPoolExecutor</code>(**`max_workers`**=*`64`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **`mp_context`**=*`None`*, **`initializer`**=*`None`*, **`initargs`**=*`()`*) :: [`ProcessPoolExecutor`](/utils.html#ProcessPoolExecutor)\n",
+       "> <code>ProcessPoolExecutor</code>(**`max_workers`**=*`4`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **`mp_context`**=*`None`*, **`initializer`**=*`None`*, **`initargs`**=*`()`*) :: [`ProcessPoolExecutor`](/utils.html#ProcessPoolExecutor)\n",
        "\n",
        "Same as Python's ProcessPoolExecutor, except can pass `max_workers==0` for serial execution"
       ],
@@ -3673,7 +3698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3684,7 +3709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3702,7 +3727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [
     {
@@ -3767,7 +3792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3776,7 +3801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 195,
    "metadata": {},
    "outputs": [
     {
@@ -3793,11 +3818,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 2020-09-08 06:31:11.392008\n",
-      "1 2020-09-08 06:31:11.642452\n",
-      "2 2020-09-08 06:31:11.885253\n",
-      "3 2020-09-08 06:31:12.143603\n",
-      "4 2020-09-08 06:31:12.393511\n"
+      "1 2020-09-12 10:47:21.057505\n",
+      "0 2020-09-12 10:47:21.312697\n",
+      "2 2020-09-12 10:47:21.556164\n",
+      "3 2020-09-12 10:47:21.816062\n",
+      "4 2020-09-12 10:47:22.067703\n"
      ]
     }
    ],
@@ -3811,7 +3836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3827,7 +3852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [
     {
@@ -3892,7 +3917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3907,7 +3932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3920,7 +3945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3941,7 +3966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [
     {
@@ -3979,7 +4004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 202,
    "metadata": {},
    "outputs": [
     {
@@ -4016,7 +4041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 203,
    "metadata": {},
    "outputs": [
     {
@@ -4042,7 +4067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 204,
    "metadata": {},
    "outputs": [
     {
@@ -4068,7 +4093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [
     {
@@ -4094,7 +4119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [
     {
@@ -4120,7 +4145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 207,
    "metadata": {},
    "outputs": [
     {
@@ -4153,7 +4178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 208,
    "metadata": {},
    "outputs": [
     {
@@ -4162,7 +4187,7 @@
        "(True, True, False, True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 208,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4180,7 +4205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 209,
    "metadata": {},
    "outputs": [
     {
@@ -4218,6 +4243,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/nbs/02_utils.ipynb
+++ b/nbs/02_utils.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -293,7 +293,7 @@
        "<__main__._t at 0x7f9d8dd131c0>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -837,7 +837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +914,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -971,7 +971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -993,7 +993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1023,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,7 +1046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1058,7 +1058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1070,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1127,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,7 +1139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1165,7 +1165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1188,7 +1188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1213,7 +1213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,7 +1222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1236,7 +1236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,7 +1245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1258,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1268,7 +1268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1281,7 +1281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1291,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1304,7 +1304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1367,7 +1367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1411,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1420,7 +1420,7 @@
        "['e', 'd', 'c', 'b', 'a']"
       ]
      },
-     "execution_count": 84,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1439,7 +1439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1465,7 +1465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1474,7 +1474,7 @@
        "['e', 'd', 'c', 'b', 'a']"
       ]
      },
-     "execution_count": 86,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1501,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1510,7 +1510,7 @@
        "CacheInfo(hits=1, misses=1, maxsize=2, currsize=1)"
       ]
      },
-     "execution_count": 87,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1533,7 +1533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1559,7 +1559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1568,7 +1568,7 @@
        "CacheInfo(hits=0, misses=0, maxsize=2, currsize=0)"
       ]
      },
-     "execution_count": 89,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1585,7 +1585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1618,7 +1618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1627,7 +1627,7 @@
        "['e', 'a', 'd', 'g', 'c', 'h', 'b', 'f']"
       ]
      },
-     "execution_count": 91,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1647,7 +1647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1667,7 +1667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1679,7 +1679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1709,7 +1709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1753,7 +1753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1807,7 +1807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1825,7 +1825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1851,7 +1851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1862,7 +1862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1888,7 +1888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1910,7 +1910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1929,7 +1929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1948,7 +1948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1969,7 +1969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1988,7 +1988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2000,7 +2000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2038,7 +2038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2064,7 +2064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2083,7 +2083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2097,7 +2097,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2107,7 +2107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2117,7 +2117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2142,7 +2142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2151,7 +2151,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": 114,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2169,7 +2169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2178,7 +2178,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": 115,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2189,7 +2189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2201,7 +2201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2213,7 +2213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2225,7 +2225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2248,7 +2248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2274,7 +2274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2299,7 +2299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2328,7 +2328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2350,7 +2350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2388,7 +2388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2407,7 +2407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2423,7 +2423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2437,7 +2437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2448,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2464,7 +2464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2483,7 +2483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2495,7 +2495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2506,7 +2506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2518,7 +2518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2528,7 +2528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2538,7 +2538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2550,7 +2550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2561,7 +2561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2615,7 +2615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2644,7 +2644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2678,7 +2678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2739,7 +2739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2773,7 +2773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2787,7 +2787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2806,7 +2806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2854,7 +2854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2867,7 +2867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2880,7 +2880,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2894,7 +2894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2909,7 +2909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2924,7 +2924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2939,7 +2939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2952,7 +2952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2977,7 +2977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2986,7 +2986,7 @@
        "Path('files')"
       ]
      },
-     "execution_count": 155,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3011,7 +3011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3020,7 +3020,7 @@
        "(Path('../fastcore/__init__.py'), Path('04_transform.ipynb'))"
       ]
      },
-     "execution_count": 156,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3036,7 +3036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3048,7 +3048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3071,7 +3071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3084,7 +3084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3111,7 +3111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3131,7 +3131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3148,7 +3148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3163,7 +3163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3177,7 +3177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3191,7 +3191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3203,7 +3203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3229,7 +3229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3261,7 +3261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3300,7 +3300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3312,7 +3312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3345,7 +3345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3354,7 +3354,7 @@
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": 172,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3373,7 +3373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3385,7 +3385,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": 173,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3396,7 +3396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3410,7 +3410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3424,7 +3424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3439,7 +3439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3450,7 +3450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3465,7 +3465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3474,7 +3474,7 @@
        "4"
       ]
      },
-     "execution_count": 179,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3485,7 +3485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3498,7 +3498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3511,7 +3511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3531,7 +3531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3541,7 +3541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3555,7 +3555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3588,7 +3588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3601,7 +3601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3629,7 +3629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3647,7 +3647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3672,7 +3672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3698,7 +3698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3709,7 +3709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3727,7 +3727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3792,7 +3792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3801,7 +3801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3836,7 +3836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3852,7 +3852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3917,7 +3917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3932,7 +3932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3945,7 +3945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3966,7 +3966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4004,7 +4004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4041,7 +4041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4067,7 +4067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4093,7 +4093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4119,7 +4119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4145,7 +4145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4178,7 +4178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4187,7 +4187,7 @@
        "(True, True, False, True)"
       ]
      },
-     "execution_count": 208,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4205,7 +4205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4243,18 +4243,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I tried to find a more robust way to know if I was in a function vs method by trying to access full qualified name (where we could just look for the dot).
However it does not seem to be accessible this way: https://bugs.python.org/issue13672

Here an easy workaround would be to assume that any class method always call the first argument as "self", which should work at least for the `fastai` library (and probably in most other libraries).
