### PR TITLE
Make typedispatch decorator more general

### DIFF
--- a/fastcore/utils.py
+++ b/fastcore/utils.py
@@ -569,13 +569,16 @@ def urljson(url):
     return json.loads(urlread(url))
 
 # Cell
-def run(cmd, *rest):
+def run(cmd, *rest, ignore_ex=False, as_bytes=False):
     "Pass `cmd` (splitting with `shlex` if string) to `subprocess.run`, returning `stdout`, or raise `IOError` on failure"
     if rest: cmd = (cmd,)+rest
     elif isinstance(cmd,str): cmd = shlex.split(cmd)
     res = subprocess.run(cmd, capture_output=True)
+    stdout = res.stdout
+    if not as_bytes: stdout = stdout.decode()
+    if ignore_ex: return (res.returncode, stdout)
     if res.returncode: raise IOError("{} ;; {}".format(res.stdout, res.stderr))
-    return res.stdout
+    return stdout
 
 # Cell
 def do_request(url, post=False, headers=None, **data):

--- a/nbs/03_dispatch.ipynb
+++ b/nbs/03_dispatch.ipynb
@@ -1164,6 +1164,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Using typedispatch With other decorators\n",
+    "\n",
+    "You can use `typedispatch` with `classmethod` and `staticmethod` decorator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class A:\n",
+    "    @typedispatch\n",
+    "    def f_td_test(self, x:numbers.Integral, y): return x+1\n",
+    "    @typedispatch\n",
+    "    @classmethod\n",
+    "    def f_td_test(cls, x:int, y:float): return x+y\n",
+    "    @typedispatch\n",
+    "    @staticmethod\n",
+    "    def f_td_test(x:int, y:int): return x*y\n",
+    "    \n",
+    "test_eq(A.f_td_test(3,2), 6)\n",
+    "test_eq(A.f_td_test(3,2.0), 5)\n",
+    "test_eq(A().f_td_test(3,'2.0'), 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Casting"
    ]
   },

--- a/nbs/03_dispatch.ipynb
+++ b/nbs/03_dispatch.ipynb
@@ -382,7 +382,8 @@
     "\n",
     "    def add(self, f):\n",
     "        \"Add type `t` and function `f`\"\n",
-    "        a0,a1 = _p2_anno(f)\n",
+    "        if isinstance(f, staticmethod): a0,a1 = _p2_anno(f.__func__)\n",
+    "        else: a0,a1 = _p2_anno(f)\n",
     "        t = self.funcs.d.get(a0)\n",
     "        if t is None:\n",
     "            t = _TypeDict()\n",
@@ -406,7 +407,8 @@
     "        ts = L(args).map(type)[:2]\n",
     "        f = self[tuple(ts)]\n",
     "        if not f: return args[0]\n",
-    "        if self.inst is not None: f = MethodType(f, self.inst)\n",
+    "        if isinstance(f, staticmethod): f = f.__func__\n",
+    "        elif self.inst is not None: f = MethodType(f, self.inst)\n",
     "        elif self.owner is not None: f = MethodType(f, self.owner)\n",
     "        return f(*args, **kwargs)\n",
     "\n",
@@ -876,7 +878,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"TypeDispatch.__call__\" class=\"doc_header\"><code>TypeDispatch.__call__</code><a href=\"__main__.py#L33\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"TypeDispatch.__call__\" class=\"doc_header\"><code>TypeDispatch.__call__</code><a href=\"__main__.py#L34\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>TypeDispatch.__call__</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -964,7 +966,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"TypeDispatch.returns\" class=\"doc_header\"><code>TypeDispatch.returns</code><a href=\"__main__.py#L21\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"TypeDispatch.returns\" class=\"doc_header\"><code>TypeDispatch.returns</code><a href=\"__main__.py#L22\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>TypeDispatch.returns</code>(**`x`**)\n",
        "\n",
@@ -1131,7 +1133,9 @@
     "    \"A global registry for `TypeDispatch` objects keyed by function name\"\n",
     "    def __init__(self): self.d = defaultdict(TypeDispatch)\n",
     "    def __call__(self, f):\n",
-    "        nm = f'{f.__qualname__}'\n",
+    "        if isinstance(f, (classmethod, staticmethod)): nm = f'{f.__func__.__qualname__}'\n",
+    "        else: nm = f'{f.__qualname__}'\n",
+    "        if isinstance(f, classmethod): f=f.__func__\n",
     "        self.d[nm].add(f)\n",
     "        return self.d[nm]\n",
     "\n",


### PR DESCRIPTION
Making `typedispatch` more general in order to use with `staticmethod` or `classmethod` decorator. More detail in issue #103 