### PR TITLE
Fix copy_func to include required keyword defaults

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -22,6 +22,7 @@ def copy_func(f):
     "Copy a non-builtin function (NB `copy.copy` does not work for this)"
     if not isinstance(f,FunctionType): return copy(f)
     fn = FunctionType(f.__code__, f.__globals__, f.__name__, f.__defaults__, f.__closure__)
+    fn.__kwdefaults__ = f.__kwdefaults__
     fn.__dict__.update(f.__dict__)
     return fn
 

--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -73,6 +73,7 @@
     "    \"Copy a non-builtin function (NB `copy.copy` does not work for this)\"\n",
     "    if not isinstance(f,FunctionType): return copy(f)\n",
     "    fn = FunctionType(f.__code__, f.__globals__, f.__name__, f.__defaults__, f.__closure__)\n",
+    "    fn.__kwdefaults__ = f.__kwdefaults__\n",
     "    fn.__dict__.update(f.__dict__)\n",
     "    return fn"
    ]

--- a/nbs/01_foundation.ipynb
+++ b/nbs/01_foundation.ipynb
@@ -125,6 +125,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def g(x, *, y=3):\n",
+    "    return x+y\n",
+    "test_eq(copy_func(g)(4), 7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "def patch_to(cls, as_prop=False, cls_method=False):\n",
     "    \"Decorator: add `f` to `cls`\"\n",


### PR DESCRIPTION
```
def g(x, *, y=3):
  return x+y
copy_func(g)(4)
```
This code currently throws
```
g() missing 1 required keyword-only argument: 'y'
```
This is because the keyword defaults are being lost. It doesn't seem that these can be passed in `__init__` of the function class, so this PR populates them after. This is only an issue on required keyword arguments with defaults as non required keyword arguments are stored in `__defaults__`.