### PR TITLE
Pipeline setup now passes tfm items along

### DIFF
--- a/fastcore/test.py
+++ b/fastcore/test.py
@@ -19,7 +19,7 @@ def test_fail(f, msg='', contains=''):
     assert False,f"Expected exception but none raised. {msg}"
 
 # Cell
-def test(a, b, cmp,cname=None):
+def test(a, b, cmp, cname=None):
     "`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails"
     if cname is None: cname=cmp.__name__
     assert cmp(a,b),f"{cname}:\n{a}\n{b}"
@@ -82,6 +82,7 @@ def test_stdout(f, exp, regex=False):
 # Cell
 def test_warns(f, show=False):
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         f()
         test_ne(len(w), 0)
         if show:

--- a/fastcore/transform.py
+++ b/fastcore/transform.py
@@ -189,7 +189,9 @@ class Pipeline:
     def setup(self, items=None, train_setup=False):
         tfms = self.fs[:]
         self.fs.clear()
-        for t in tfms: self.add(t,items, train_setup)
+        for t in tfms:
+            self.add(t,items, train_setup)
+            items = t(items)
 
     def add(self,t, items=None, train_setup=False):
         t.setup(items, train_setup)

--- a/nbs/00_test.ipynb
+++ b/nbs/00_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,12 +85,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
-    "def test(a, b, cmp,cname=None):\n",
+    "def test(a, b, cmp, cname=None):\n",
     "    \"`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\"\n",
     "    if cname is None: cname=cmp.__name__\n",
     "    assert cmp(a,b),f\"{cname}:\\n{a}\\n{b}\""
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {
     "hide_input": false
    },
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {
     "hide_input": false
    },
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {
     "hide_input": false
    },
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,13 +470,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "def test_warns(f, show=False):\n",
     "    with warnings.catch_warnings(record=True) as w:\n",
+    "        warnings.simplefilter(\"always\")\n",
     "        f()\n",
     "        test_ne(len(w), 0)\n",
     "        if show:\n",
@@ -485,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,17 +523,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAACCwklEQVR4nET916+tW3YfiI0xZv7CCjucdFPdqmJFFilSpijJoqBuu200ZLjRkA00/OQHP/nF/4H/ET/YMNoPtgW4G7blbuVIScysKrLIYrHSvefcc84OK31hxjH8sIv268LGwtprfXOEX5r47/7t74rA+fiOlGFQc8xD8N7qTz790t3du2Veak0hDOO4IwXTZXo8PAi34EZG6jt3fbN3zk2X9fd+/3fu7t4qRd4O5/Ppt//tv/j93/uPUjmEzvhOk3JG7ze7b3zr6/+r/83/9ub25vXnnx/Py6uXz6/32/1+31o7nh6n6dx3G+uM1jrGxTl/Ok0grI1a5nmZL12/7fs+dG4ct8aYzz//nBs656bL4+Hxzljb+WDCuN/vjVHW2MfDIxFa6+K6aOPWWKxWpZTWmjZGhE6nh3WZvR+s1fv91Wef//TZ7Yta27IspcjheHj27IU1uN9vjTGN6/t3d+fLyftBYfO++4sf/Wi73cWYjKUuDNM8Aypn3eN5XuaTc3Yz7obO1xKFldIwz+v793eI8vz5i+PxeP940q3CNN+fDm9evPqKceNpebh7/8UHz68RqO/76XIJYWOdLSVTa8MwGGNLTufz8frmdrPZOmdZmBS8evmB92673VrjEemjjz7a7K/+9b/4p6kUbUVASilLXL94/cUP/uSP/8bf/LvT5chNee83m1Epdf9wDwD7/T6usyIHAMZYrY21tpZcq1TRV/ubYTMqbbQma826Rmbo+67WWPLqfNf14zCMXd95H4SFhY1RIpBSIqVjzJdpfXazjZFjzDvvjDXrqo/HHAICYi556Mf7h7sXz1+llEJwIs0Y7PpgrEbAy+V8Pl+M8YpERAPiy1evTqdDSnFecteNuSSlbcyokL1BBM4lnWYFNc3zvN8N3jutdcppWS9EaDXq1mpMyfoNKOecfXV7vXaqG0fmaowlpNZ4ni/WWGus1iDcuj4MYz+OPSKVWkoutbbr61vrjCL0wRPpYfhG6Mac67/5l/+0lEi2I4GU8/F4/tEPvv+1r39zv9/d3r4chs4YfTweT6fzdrMJoW+1TtNpu7tiViklazWhKK2HcYNSBWCN8eZ6L8Ln89lZV2ttDON4Bdo4q7uus9bWWktJRESIKadSQCklwkNniDDXtsa1y7ZW2e1urAnTNIPAPE1d1z8eHnPOSqlay+3tdT/0RAgAj4eH4/HoQ+g7l1NZYgSQoe/Pp9MwDLUWBAjOI1EIIStYMYNySOb+dDGYx6Hb729Titaa1riWNs/rdDlQKst+d3N18/zzL17/+Y9+yK0U0Y1Vrc0aiyStFRH23qdc5nmpNXd92F/tADHlFNc4L+tyPjkNz5+96IfBWuec7bruk08+/c2//fc++OjjlCNLY5GcyxTXH/3ZX3zvj//g5uZ2sx1IYS757u4ORFqr8zyPm51SKsZFa02kam0+dA00sMxrWZZMZIyx0zQt82KMFhClXOi3fRf6vjfGiHCMKyLmHGutrcllOjGzUuScbY0FJJcUU06slpRDF7TWteWUUsrx+vr6dD5437G03W7s+4AIp9PxfJ6cG5xzStvGKAKtNWvtfn/FUj744BOltHfeGrMsZ9LU933KsbUaNN3udx+9+sAYdTi+t1Y5Z0tF710/XlHfDYqw9+F6u3PapALHSxMAJLDWKqUQoe83AOC83e22z1++9D601i6XyzQtCEopxdAYOHS2C51zTivduDK3D16++rt/9+8Za7llAmzCLHI+Tz/9ix96H7wPiHR4PGijdrstSKulCMtuf1tybjUZY73zpfHD43la4p/86LOYy9VuFJF1jc6HZVlqidYqAe664J1n5pSSUqS1FkYBGjab4J2xSimllBaR7dCNYzf0wxhUTZG59X3vXBjHjSKz311prWst4zAYa2qt5/NxWdauGwQorinHOI7Dbr8XpFxbCJ6QmmTrwhrXUuoyrwBoXN+HYY355fP9Bx+87IfudD6sSyJFPtickwhuNyM577Uk5rLZbD755BPn9ctn43YzCAMA+hAQkVCFLtzc7Iex01qXUqZ55obWhNpq3w9C7vMv3nLj0HnnHCk0mpzXX/nyl/7Ob/0nX/2lr5WcKrPWhgFSbfdv306Xk1Z6nueY1mHohmFAYKXUvMwIcnV1k3IsZVWauFWn5PHhvsS4247W2XmeAdE5X2pe5pm5aE1a68at1qy1ZubWmlKaUDtrX7x86b13zolIa01rdXN93YDmNSuieZ6cs4oUM4tAznm73S7rxdpQSru/v1vmqJQympy12iit9WVZSq3SWsrrPF+22/27t58DgAuh6/xudy3S1pj6Yby6uu77johOp3NOdbu9EZah7xHh4Xicl7NWGsF15zlaa1JasVWnVC6p1mqd6fv+cpmfSgqilJKXZa21amWIVGspV6ZctuNwPj+uMW63Y0pJBJBESlOKPvro4//87/+X/4ef/TzlZKxrzLnVu7v7P/neH3XDOM/rOG5rLalk1K4xEECu3Hd+HHcPD/ddaATU6vr65z+6e/f2D+XQbzY5pf3++uWrj533XfBd1znnEaGUZIwVYRFkBhbRhmopXd8zS4xRay0igOhsEKjW4HyOAISIpRRECsEZi8aYdV1Zyt39aV2id0GgxPWsTG+tJqXOl/vtuAMo0/HcD1vr+nYP03y6vn5+Ot4ZY6Zpcc6PY9gglVzevHmdUkZQpa2IREo/u726zEsqqFvJc+JSmnMtl5ziorX1XRCEeZ5CCEpRP4Ra8/l8qqVp44d+qLWmvFhrUcE8X5x122Dn+bLdbmJcnOus8YScckaSb37r21/6ylf+/E++X2rkmhnAEPz2v/wXzz/4+NNPv2qteXg4TNO9ACvtrvb7aYqlpO1mHMfh8f7+3bt3f/wHv/eXf/L9y/397xCANttx8+LVy0+++a1Pv/L1r33jG96HWguAGKNBaE2JiFprShFzS60prY0xKcWn1wHAWiutzvNUKzvnSinD0AuA9y4EByDD0N/dvSM0Ma1dF6ztm3WtSGNpre3H0VhFOFwu07gxQHj77MXd+zfb7RUzCufQddvtuBnGXMvpdD4cj0M/iOTtZpOKAsS+D9f77d39o64NAICItVLzUlIpt89ebrejUpobGGND8KfTYZpmZhn6HaHOJV8uZ6XIubAdu7iuP/3JD1/tXOduAPDm5qaUCgAsSSkch11M5dNPv/znf/K9WougXpZFAXz3j//4W7/6R1/+8pe1pn4YsFzmZTabYI06nhdEfTmfUZnv/uEf/PY//+/ffvamNdGKQMAaPsTj5TS//fyLH/7RH57+0//xN7/za9baEJxSupSMqJSCaVoRcRjG0+m8rg8vX7703rcm1loRISLrbC56HMM0zwASOkek+r4XkZTWGFcA6YIXEBGZ5wiIBCwgxhjnN3f3j9753e5aa2+MC85Nl9Pnn/1oO95cpsPV9c1msyXUd198kXIex21rebvZ5spzKqTDoNtmM949nHQplZC7Lmy3Oxf6nNftdmOtRcC1rIfjKee8Ljl0g7PueJm0AlsoxXXcbAAgpdwF/6VPvtx3obYSl2ncXrXGIqwUEREAeRu++e1f+Wf/5L9rtYLSwhxT+uJy+Ff/7B9//Vu//KUvfzVlaDo8e3llXFdKCc7VVv7ih3/+l3/2g//4L/7Z4d1b64N2WgSVUq22KtJiYZjP58vp9N/84Hvf+/W/8Te+/u1fsQ6ZARFEBAC4CQBore/vH29uro2xpawhhFIKM3vvnLu+nKec49APWpvQBUI1z+fj6ZBz3e+up+l0tb+NadEa1iXVGruuLyVro6212lhhPhzvAWSz6W+un//pD/74av8cAIdhRFRv3r798Y9/dHVz23lfizTGyzRPcxy3TunQd/p6t9VXVxsAMFoZa7XRxWAtMa7TNE/MYozrwgaI+uBFBM4FBZa19V0Xghduh/NxGDe+86lyTVlqcaE3RsVYldKI5XB6BNBf/8a3v/yVX/rBd78rlhBJFAHRn3zvT//Rf/t//wf/1f96u78lZWLm0/meha0x3//eH/zxf/jXj599ZhlePnsBzAwopFrNEURYUKQ2JlLH05y+/2enh4e7d+9/+dd/48WLD2urRitrrQiINOds1w2tgXO61sLMWplSW4NmiJ23V+q677sQPCIty3K5XGoRZ0PXdaXGUhZFWoRD8K9f3/f9xlqjld6OPTO0CtZoRDodHm6efXhz/WqaTh9++KW+G9+9e/fFF2/GYdQoSApQr8syhN4Zu87vxN1Y554/v9XGKBFOOaYc12XJKRqtC7Nz/WYcW6uAaK0zRi1rwpa5ZmUH33VxnhRURaSVYZE3n/+477rth5/EVIxWRJhzNkb3CIi2lO1HH3/yp9/9Y66FSD0dD+b23d/5j7/xm3/nN16+tMbd372vTb1+/bO/+P7v/fS7f1SWVUS1WpZ1VaREQBmtjdEIiEJaF6Sca2Ux2j7enX/33/y748PjX/8f/tazFy+dHax103Qxxlhr+q5LKRmjtDbLsvS9AWECTaRCsF1H1loAmefpfD6va9TaaKVTrpvN/v7ufQjb2nIIvbN2jYs2Q6ucMi/rGYSNMaEbEPWynLbb8e37z0vNr1+/ub+/d9YMQ2gNSi7O6lxiMGEcrn709mc+BLHBOaUfHu5LyTUX750ANlHBbrzRzmkBlMpau9qaZpVb7YLNy6wUG2tLSkCADACijV9TMSYdTsdaavAvuq5blsV7r5SOMW0346sPP2ThVhk1okhrzVl/Oa//3f/rv7158fLrX/v6fHj/szd3f/Bv/un9Zz/DilOMS65SCyA6Y4CZKqmkgnVGKauV14atnVKpLa8ZQNEP/+QH83T5m3/37/3SN79lrR2GUSnUWvVDYGZmds6t6yos3hnnHRGKIBEppY7Hw7t3b7W2IXRK0dPvR+S0VsxZGI6Hd50qztpaOZd4Pk8xzpsxAOiH8yzcrodxu9mK8M9//jMiI9LGYWNsmDNwmYok64L3fk3RdNva5PHd5+M4aq29MR12uN9v5uXy8HCc5ov3pLAHckTSpM3THKMprQ3dLpfsfS/A1rtlrQhRac3crq72VpPV2jvHDIjUdQGRANBaI6Jub2/2+93bu0eQkhSiUILMlb7/x9/9//w3/xD+y//lX3z/T77/7/71+eG+MaZcphinVDRA512shQubito4owVKUgAo7G3X7TbLmmIpzYdU+Oc//bnCf3X7/PnHX/q0C8jCzNx1HTOnlAHQe19qGsYtgDCDCNdaU4pv377t+2EY+hA6RGRuWqvWpB/geHhAMill53qlCEgva9RaKVJKmday005bt93utDJKK+Z2c/P8dHoEBFR6CBQhvD+cHIBa4rt3X7RSrPXXV69qXbXS/rIkQ01pba0hEOamyB/PZwLV2jpsbp1zS1wIELGbY0OL1Aet1iYkefrpj/7k2ctPP/rwY0BmBkFVGADAe38+X2ptIXTn8+mXvvb1X/8bf/sf/b//nyJSakUkqCBa2ao++7M/+8f/t//L+f5uPh1S5so8rSnVVksVpVrlJtVopxVxa40bIcQUPfoSp9Epv+1OS+ZawZhW6c3nb//od3/31YcfO2eQEQBaa621eZ601kpRjDnGWGtlbrU2Zl6WJefUdaGUUuvpaUwyxlhjiGiZZ0D6+JMvA5AxqtVKigjxRMAihPzy1a3WelmWL968iSnd3jxPabm+eXU6vHPWAerCUtGN2uS4EFYmSCmP263Eqo/HBwDywYOgc85YY4xXmuaHc61NGwt0QVSx1CE4bdyLFy8rE6PW2o19qcqVWYjMZZpAKRCpjUW497fG6Hlez+fTzfVVa/X6+vkvfePb9N//I2jcGhAJNyStXl7vRqvf/PmfF5FYSkypNZ5TKqUqospSGiqlrFZOERD13rVSGrfamnG0LJOr5XrcNTLzmlipxvgnf/zdT776lW9++zu1ZhFhlpLz+XyxzlnjjHbLEpVSiEikEWC7NSH4uEZhJCIWBgCl4tM0pY0WEWOssACCNrbvWCntnI9xyWnpum5dlvfv3y9rNFo7Z+/u31nXuTCUmmNaQbDX9XY7lKwu0wXg6cdup/NBGzsoiI2LQANAETbGDpseQEqulSGucZrPm/3VZrcT0n2/SU0IKnPRBoK/6obtnPhHP/lxbe1rX/7qfjOKlKd/mwhzTiWvhJpbu7p93vfjfD40AQMAwoN3+3GY5nlaIwhOOeaU11w0gnoaY4lIKRGJOYpxhAJLdNZoo1CAazPO5JQRD37YXg0hgkqlzdPy+//23263u6ubWwBUSmntQwfO2if8TkSIkJmJNDcOnY3rEtdYW7vZ74QxP/V3ZKUVMLdWD48PpWYiMsaJtBB6ranv+q7zpdTXb17HNXkfgrdGm1cvP5qXy37/alkerVUi9MX7u5ur/eV8Dt3W2dzKUkq0utPbMSBYZm6taq0QKaWU7hdubRg3StnZppubvbO+650wCGKrEJdz8IrKWoVU2MV4uEzTs6v9duz73mkdci6Pj2el6OpqZ7RWpJYl31xffeOb3/z9//jvDZAGcka9utrGdZnnJbMIQow5tYYASKi1MUqXkueUEDAo5RSIgjkmEbRGa9JVFLMQCyVhmboBgvebwU9Nvf38i9c//en++hmRcs4krJhxXuar6z0hIkJrDZBAhBQiIgAoZVlYa8XMnCoRKKXXuBhjrHNaG10cIuWSz+fL5bI4Z7qud8G/fff+eDzeXD9TWqW0IsC42S7LtMQLaa+wGqU2nZ2mEwgao8m5x/uZufRDoIeH9/N8AVQ5N0REIuZ2Ph1SSqfToXGNae37npS+XCYALrU5kpKXh/dvm9jEVgA6b7/80Ydf+/KXd9vBGFVKfbh/KKVuNvurqyutFSAi8bOb61/+5V8x1hCh1urD67235jDNa6nAnGKMOUmr3mjvehbMzEWk1FZrqwyxVmsdEq4pLbmsrQICiBJBBhDBUuv0+MBx2gVNAH/5p9///LOfny8XJGW0Gvv+vKTH06K1bizMQKhSSq3VJ4AIgI0xWutahVABNKXBGEUk3lul0ToSIm3Mbn/tXceslmV5//b98figjR43w83NbT9uG8PhcB/6bVxnY7paJeV4fX0bQudC6IJFEKWddX7ogz6fj133wbQuOz0AIBEhmNvbl0S4xkW4Gq1a5WVZYlz7rieQebp417WGP7lbW43f+NRuN93VbtMPgwjP8zxNEyljjWVuWjnWuaREIAj44UefXN/c3r19+3w7brvu/eMxlYIATzyJADDLWlm1BADGGq2MscopIqQ1pRFl029Ol1Phhk0tcemHHQIoQgbQqBqpaToPhJvx+nT3/v3rn+9vbrhVEUaUm9021Zpy4caNueWktdJaa60VKa0NIKYUc8rWubSmGBfrRq3p6YiIyP3h4I2xiokkdIMAwJL2e7eucVoioHa+D91GHVRlfTwe4noy2q5LUkoDVmsti2KpwzCmuPR9rzdd74xOSyLSWmsAQETrQhOwlp3z3ve1lpRmFqy1KUUpnsftNZZuenjcBuz7zjkLAI3r8XjIqXgXkBRAK6WY0DnflZKNIufcJ5986evf/Bas86vdfo3lkrICtlrX1gqLRg2KmXnlaq3zpJkzgdJKKVKt5sfHh77fIilNSrhVROIKwEXYGg2ExloUvpxOlbkbxzSddttRa9NabdDG0Xe1LfOslTHWELLWpjVmZlJkrWPhUjJLtbYjGrnVx0vsHJV4yrnsr18Ga0+X8822s8aI1DWuImisVmrUPqy5TMezVjWEAVkNw/7u7rOvfPkb83QWSUrROk9zRkLaj4PS2PW9no+vncrXz76KSNpoa03J/PD4cFnLNqguhNpqKcX7bpmn8/EujLth2IYQRPJXP7jejp4IW2ullPP51Jp0YWCBlMUoePqIfd8p45SpWHMI4Ztf+3r+/GeXZVkrMwsS1saxSGosUhWRIQJAAKjcaqmqiSEi57wbLtPlHJM1xnDd9cE5o5RmUqAUCOXSDIomgsrT44FLuRzuuVVEeXp+c85KGWOMc84YA2BLqQCNmYkIEBAJ8YnMqsYQMxTRlRHQgOQYo7f2VFOOgmK1ssH18zLHdZlPj/3mptveSOimZZ4fjkXwerefp0NKqzYWod3fvXXOG7tBwq4P192eW9NXzz8dhhGpArCwGKPjuhLSi+v92HeVs1KmVlAKnbOoSAS0Ca1x39vttvPepZSOhwOLWOutocPjXQXs/AgsIq3UCoBEFikSMiKWdVljPC5rFQAQJViEGVErnUvRSudaGaCUUmrttKmNK4tqVSGY4LlJZ+y0zqlY67tmbAPUiIAGjWVOopS2AVuJa/zZn/7pz3/0w699568Js4is62pt67oOEVOKShEiMQsgEhAiKSKtsIl6f7o82wRgMNo0EGP6jlBr/cX7t0pr70M6PzAWs/+oNUbUx8eHGKNx3lmLTSXyc4Yltn5z+3h4/+L5ByE4FhRmUgaJNtsBBT9/f09+vEYbrHUsyMxPxF3f9VphY+670RiV0wqojfVKm+BdCK7rfNcFpXBZl4eHe2bZbvbO+VJLazmn2rhIq/dffCat1VpZoNYmwq9//qM/+8Pfe5yWwsKNc22l1lg4l1JbJVKVmRShACE4rQRBEQBCa7W2SkSEQMidsyyw5pxyYRYAyWXNtQiSds73PvS9NnY5z//xn/+T+/fvSRsigtbidBEGZgYQACACa51SBomUUq21J8pPQSOlSNtdrwavuKzLuq6xlNKMc2HYeN+J6nMuIfi+GwS1oLLGceNaV6PSqxs/dr7WCgK1pi50r16+Sjm9/eJnwFWhuru/u79//4Tk3cHu6u7d6+34DaV0bZkaDH6jrW1A3JrRmpRx3jlnvfdaKwDOuczznHMKYQyhKyWKSBd6AFyWhQi5pvPj47i/DWEUFufCmzef/c4//8fv375rgLHVlLNRCgEZ8InG0kY15qANQdVKeW1QKa0UAwoqILSanA+IqJWtrSmBUopDBG2FWUph0FwqEGhtkRQivPvJT/74t//V3/rP/mc5p9D163xurQECESKACJwuly2is6q1CiBKq+BAYw8gSBg0lVKjAkCVUrq52jhjjDawuy6XyVqntOIGLz/4KJcE0FJcEVAROqvXlLwBN+zPp/O6LF3fXe33N9e379598dOf/WSaJkVKC6c3P/kz/uDL8zQxg1IKAUEAERGwtRpT7oetc84YbZ1j5pTiskylNGvdMGyVskvMJSWtkDXFVJ2zRII6dJtNjNGHJMKK9M9+9Bc//rM/n3MtjVtrjdkQEmpu0pgBSTEjtzU1JKU0VZFeKa0MKyW1acSvfPD8ert/OJ/ePV5aayBAiAgCrXbeD/3QdV5xq9KMMUppH6xwu/vxX/7wj3//xZe/ut29MNa1JvM8dV0gp2rJXLLWJMwIaJ1jkdaqgIg0rTQpvHvzVmvTb/Y1Z6XoeH+PnN0wdv3onGmCx8dDYx7GXUmLUVqUarVoY5HnFNdx042b54+Pj/f3D5tNv9vt37374uHhXpFCBA2gtAvGuWf9h6VmrRW3FpvUdri5vtLGbDajtZYIEamUcrmc5nkyxo/j1hhVKsbcEESYY15cEGc0kAKpxpiXH3+ZG5RSRPiyXv7iu9+9P5xi4yoiAIaUUtSYc2MBMIoAUJEGgCqcaymttca9AxvUJ6+eaWnPr/a77W67G7ru9Ob+SIhWqd0mjMEoEMIEMQopaIXFxVqBe+sc1PgXv/fvl2WuKY3bXWuitCo51pqd60kZQhAWUoSI3ORJC6I1EakU48PjBaQ8e6aVwsvj/fn1j5dx9/HXvoWkHo8nIj3Nl1r55masrSCZFNeu74hUTotAG4aBW91sh5DHZZnevHndD+HD7ZeWZV3ipGtNX/rqN7Rxl8uJG9uu01o1lu1247xXiozRIlJrSSnN80UpNw43xmjhllOt4taYxkB23JwvCICKJNUqnHOOT+s+CGvlP/vZD/7yz/8siyAq5CoiDFKbEIJWSiEpIkHIrWmlQAQBDSkBGZz+6Pn+049fGGWmy+VwfARQz66vfPCt5CdEYr5clNLLPIuA81ZaY8SY23bTfN8ZpXKd37z+p3/++3/w6tNP/TB++OlXhu3oXEiwlrQcjzgMA7c2p4rI47BR5heD0zytXbfhFpWSoR+nx3uybnf70lr7/v39NK03N9eh2yqtlZLaBECIyDtfco0paUWIGGPMuabSxs2m5BjTVOq82e591+kUox46EAmhb8yI6IMzNuz3OxGIcTmfVxEwRlsb+q7n9sT5cSkZQHKJvfcCoBSQdiVHa3Wri9E6Z17XdD4f+y441z778Q/v7x8RFIEoxNq4tIqgvXOaqDYWAGZWiGtKVmsE9JpeXu2//eUPdrv9Ok1Lg9ZqikV1w8rnVorUKLVVIRZYLrMiVUsRgtCPx8sU3CCoY6yJKgu0Uktp58ej0fpH3/v+B1/58mZ/PV/OZT6PVzfPPvywHzfGd8F3T4qQJwnp6Xxx1vTddW0ZSY37G9v1w3bkxkTknAOpm8GzYGut1ZzL0veD8+Hu/gFRWUtPfzkMIy3ROuudVgov0+l8uRjt9fPnzxs3Y4z3rtbKzMaY4N35fIjrElPSxu13e2OctZabfnx4MA6d646nqZSslAYoXdcL11bWWqsPxjtXK2tjEWlWS2nEKb774vW0rqINAoEwAgpLJa6tVW4sYJQCRGH2xrE05tb7/mufPHcE9+/eT1NkJOM9N+E5ZipQi7TsjAFh0sY6bMzQJFV2ZMWEtTWJSQQ1iXMeAIGwpEJKP7x7u5wPpUqOq5U8juPr2+effuc7zz/+tO/C8XQYhsEY01oz1qxr3WyCUn6N0YduGEZGPiyQaVRmWuZlHHzwQ2XUDHF5bC1pbZ4YBe/0+7v7nEsIJgR3PNxZa7g178aU0/3De22tbkwAsCxzinFCiXGNca21ej9c7699cE+HkUgpjaRAa4WEznUgahgCkkopa6UQZegDIfow3D/cBe9d6OJQj1O0UufziYiqgICQUpyLIAhzaZVZnLVG68bcBBBBoSLCj57dBIS7+/NxmmNp5PxQqyFsiouyaZ5Kq/vdPli7rgtp20SU0k2klDL4sKRlLUUBIkKiKgC8RARgQq10XFJtfD4eLNd8vuTLOU/HdDkqo12/1cogojVmu9mGDgCa1lRqQ1KxZGPsWrImNsauOaUqbY1IKudCSmttEZEQALjWOk2XYdy2mmO00zRvt2Mt6e7+9atXHz97/pH+4u3rlDJz01oLSwh96DZaaWutUlqk1poAda3VB+esN8YIS2sMAO/v7s4Xd3t7ywytNhQpaYnMod+OQ8/MS4qXdQXO5/Pp4e49A4gIEnEDARQBQGARFm6ttVZLY0F0hDeb8aOb/c7Zt+8fixCRYZQ0z4ZdQ2UG54zB0HNcH0/nzgcgiqeT0cZo3bilmMhwqw0EYk02+HWN0CoEX1vrFXJVgIoBkfkyXarGVtJymdbTqeb69d/8LRwGay0IswgRChBz6TonjEtVWPPtoBTZeY6CFFMl1UqMtXHXdcbYUnIpVZi7wX/w4kZbnwrfndo4brQiqwOBHA531zfPdErZmuCc9943Ju0cSE05Kk2AjWspuVm3KbkwP9EUSgS0MlpTjfPd5WyMGvqBSAmi1n65nJuchmFDRNO8IrMmdT48XB4enhpva1UaCPMvgAhARaq1lgqygAB/aXf1nU9eOqfPU36cs7ZmjXmKafA25tz1Y65N1oVJMyEz5FalYSoVAJTWgFRrBaQ1JmNtyrk6n2pupVYErk0TaOvWXIkbtzZNs+5C1QytnQ7nn/7h7wrCr/7d/8zePgPAvu9aa8zcGiFA4daEUqvbDhqLNfTs5poIU4wPy2S07/o+dN26xlqLNtT3PQArpdcUkWMIA4PuHL/64KO7+7uUon718hNArCUD8Hl6zCdwigDq2D9nFm1srS2mFUBSLNZqpXQpjQidcy9evTidzoSIyMaa1ijG3BiI4Xg8GmOmy6H3/VqVMEhNIiL4xIQAKYKCjUUACEAbQ4Qt15ux/+Rq12mYc01NjHWx1MQSum5al6CVq6wNpVwYayoFRCpUa2zoOxRurRoXElcjrBTW2rjK+XJxPjTkWGtaVi7ZWitK15wdyNCPioBrVcNQ0ZzP00+//z0h+83/wW8+e/nC2s4Y86T5BUEk3iLnIu2JfVUgUuc51lKDc6SdJtBKp3gEEKMJlbJhlFq81TdbzyJLSq2U81TmtQKctNYq5SRQnfW1FoUYwka4KqWexuLCGoX7zs/rMoxBaTvP53VdldI3ty8BAEmRslprIkREY0gElyVezpd37764uX6m7Xh8fB9Tqk3IEBCiAqkgAAj4pOJ/oiKM0x9fbfa7cW3ycJwOsYAIkcqtJRanzbxeRLlXm31qiVs1JggXBmkAIKC0bbVSKQKIyEabVBsgNG6AYJReakatYq25NmvM07RjnYunRwp2Op9VGAE1nC5/+Ye/R8j6b/6dcbtHRKVUShEAt9ud0a05nVJ8En4hwJpEEfquX5alNsPcckogEkK3rFUbl/N0Ph23m+3740pKE9K0pLUQwapZmiJKKSlSxlhvjFHUjTvvfck1VyHgxvnucdWamMVax8y1lXmZck655O12b50Xqa211vLldHBh6PuemW9vXtWW23qRWhE0EtRWgQlINWbm1pCYGxKV0jTofdftxh4A70/zm8fDMZXBOSQdS9GKOt/lJvPluN2MKFhqJUSFihEaErQmOTtrDalaCwtp40qLf9UNm9SyCcOyLECKWztNZyXc+6uc85xTCJ60B2ZibGs8zfOf/od/b8Pwa7/1nxBRTvmJvj+dTtYaEVBKK41U0RhtXX8+H6111oauD6WUXAoRdc7N65pqqk1C6EpNY2e11gjw6nbzwYvbmiOdzwet1Xa7d97f7K+sNYjovWutNm7cavB6M47ny9kbU0p+ckCAiDFmGIba2vlyJqJSai0t5zqMW+vs4fgupsVYKyLn6SDYSKMiQkSjNCAKICIBAhKCACAC88vej9Y+XOa3p/lxzYWFSFVuDQARp3WaUpljvsyL1NxqKTnVVhWCEjHWamettQCA3LRShmg79CGElHJeFxZZ85rjQoSIUEplbjWtIhILp1KtIgTJOeUma2rn4/kv/+D3f/iHv59T0tZ73w/9CIg55zXOh/vP8uULrZUxJgQzDL21mgERaV3XVtlYw0S5lJrj8XgutTpjO2+cBm4FkbtgkUD3/Xj3cD/03Xa7JaKcJ+MGAW61INjp8rgc31xf395c7YhUrYIoRCgizgVj6ObmWYx5nmbn7OF8t9nuvA8pLbU2pQw3LnHFVpTWAgDCCrUglpxbK0BIAIZUqY0Bng/jl55fxZTfPZ7nwrFx52xuTZAskSKVckq1mtDHHBFAyCitQSntbMtVGEgp1CaXQoQoLc8TM4duiMZwq0qMs7aZ3FpbYyolgbRVYQWamceUzscHF0bb99qoeZnqwo9v33//3/3LFNePvvmtrh+90YrAmCASoOZ1nSKfnpwH3vvW2jKvtZacCykCkdPhvKxZaeq6Til1WRJpl3PqvFG6my/n6XLStbTz6VTi4pxjZgBkrrVWRMol3b99Deu7Z9dXNy+enS/rsuTttuuHYV1ia7WUxq0561OKXRf6vjPWllJKKV0YWqvn+bysizU6eGesAUABYWEAFEEWoSeqC1kAvKZ5WR/XvDbOtQkLNxFDikiEEcD3m53rBWRaotaODNbG3lBhtN6XlKDWda7MTSMKsyDW1lROzhhRupTMi2hra61NWsq5SAMRUBoFDutCmpxvtXEp7H33cDw559Td/d3Pf7p78cqHodbaSrRbMy9rN161fk+KpsvldDqFELwP4zgAQs4p5yhiOu9vrvfrmktrIPxnf/n5q1cfOGtq5fM8cTppEJovx0E3BEgpK1KDd0okpfJU8ppUY611IeUEwohSa/M+iAihSnEGzoANAGNMXT8QonB7WiPW9bIsc2NorYVhM3QdAQoityYiiCTMAE84NDhFV97OMZ3XnGpZU2KU++l8mqaYc21cmjBQ1w9ca2Uutc1rbCCpFiIEhFQyM5SapZW4rtMaY4zMXGrWRgtRQcy1Ka2A0BBprZZa7y+XaVmLYG4kaAW0IZXiSoCNZZrm+TLfv35zvn+rFYmwNjrlnHPMKee0EEjfd10Xcs5379/Ny6XWQkTb7XYzbkkpFhQQRFVKU9rVOPUWiKTzpJRJtVDoei7L0PdEirkRVE2ilCbSpRQGMEq1WoVBEYSgn7CKpzKqdCDtlFJKk1IEgCWnlJaYl2k6LUsEgD4Y67xyg7a2cpXGIIKIWiuAp++fmUUrUgpzbbnxlEtpNZWikIgo58QsBcn6gIgppVILKyJtW5PQDSCQchFBbTULVobD6cg1z3FdciolI0sp2WkdjLbabDZbNK7UpokqwJzWtaRCdKocSSERIi45ISkgteYyTfPd55+t0znmXBqsMfddV0Vp29fKJadx3BijrPWIJsbovdvtdvura2M8EpGyAhahfvuXPvTWPGHB3rtxd9tvnlOlLuw/JqWMMct8Ft1rP6Q0vf/ip8eHL/p+QNvPmXMpLKy1zakqRbW1lBZCLLlpsptxEzrfWm1cUArXejqfp2lSiJvN6EM/XWYQcVopRYDEAAjwNHoCogiXyimVKZfETEBP69449M4op3Qq1VkHiDGlXLIgFRYByDnXUqCxQkQQrgW4lZQayJwzIrTGMSVp9UlkCKiMsUjaGL0fN4YUAafaTtN0WefLfIm5TnFtIoRYRZ70E2ldDl98cff2C0JM86yVRuMjq8JESFqbEILIk1IAx83O+26azufzoe+7rhussSBFab3ZbK9v9iH0uXJKuZYiIIRkh+3VvK4ggHZ3qkNha7UDoaur5x9/9JXbj75R0ac1rWuupbKIADhrUozLcjbWamuMsSml4/E+rYt3PljLrZQSh2FA5R8Ox3lZnfOKqImwiDCX1gDgifkhUiKsCdZSU05aUWUmBBQpKcWSi7RcyzTPp/MZiIz387q2xkPfP3lOoVaj1LpGqVVaccbkdZFWNUoqdY4LNFYC3mhF5Ix+dvNst79BUr3vUKnU2rSuIK3VCqhL4VqK926OS6mptRqnS4kLlMRlMlYXJgAkaCmtIPJXdL+2VoGwNX4Y9qWUab7EdbFObzaBlMppGXtvNXKpOWdu0SjQUi4/e/PF+/fvjPGFgcZ9cHSZL+clmlCC8DSdc6rC0vUdC9d1NQZ9CPM0e+/3V/t1jXeHh/P55Jy1LiwxCdc++O3mE+u6z794j6A2u70fRkSQxu0J1yMqgCzCzCLijBFhDWIIn3qA1qq2ZknlWr3zRBRzWVN0zlZBYI5x2W831BqDVK5G6SYyrVPOBQlzWjPXXRgIKK0JW1XGW0VlXTe3N6KMS+Xm5nlZL7nxtEZurIFIyhrXwfnaMrfShQFQl1JPh8cvfvrTl1/68nj9CoSxJUfkDRUB42xKqeSCENUYToe7eZ43u5v97jrlfDjcO++89cH3ILDGOF9OSlsF9XQ8aWvoez/409/5w+/v99daq91oR51qnA7HS6k8XS5N4Pzw/vj2L6wGZ32tVQByKtpYpXTXdefz6c2bnx8O98H5zrmclmWZaymbzcaF4Xg6tpIF4Hg8SK1OqSfFJyISETzJqQEAIDdOpTFIFT7NS2sNAZRSTYBFvHHOulRrqrm2xsyAWGqa5rMPwWqjSJUYCRGV1tqsT9pewDmttUZNSEqltKZ1RpQWo1a0u7p6/vLV9fXtfrNBpQCRlfLdiMrWWoXFGKuMIaVFoAhN5/PlfDS+K6Wty9lpKI1TLt67Wou1zlhbaj0+3B3ev76cD6SUAO2unqdY7h/eI8K42QNa0h2gQSFrLDelT8fjzc3ts9sbZQaiFtcHIn2922tjvbPG6v2zV2W7HXd7az2iAHgAEIZS07u3b3Nr3rjNuOOaapyU0n3fQyvaD8fj+XJZ397PRrEmRBSNgICIJALMzMJICvAXpagwWFJckzRm5lpba9WQagzO2dJyLqkxzMuaYnp2c7Ppt1qbyzxtur5xnWtypAxIBUkpIYhSJASp1pxjX3tAKKTycrHWYHLj/togKOZbkL94925eFtDWd/1aKgprINRmLpUJAZEEgFQ3bBVhaw0RhaUJG2MRVSlFQES45iJk/eZmGHcijUicC7Ddn04wzZdUSvC9cd393Vvm6rtunqP+5a9/1YZhjRFVddZ0QV/mddyMAIgI3nv7/CWRAmRCLKWs6zJNkzYaAKxzvfVdGFjydFpzY6vBO8fgUpaUy/tzefOYnm/w4f6xVNZKiWQU4NaeJOCaCAEQpEk7l7y3mlsDkMYMICiw5gzACLLmtqa0LJMxBo2V1ozWIXSn0xFEOmMQ6HQ59cEToSAKS6rVKJVrKyk6bbSx3Jom4hwNXRmlWvCj7AXharObUp5yySCkEBqi0toYyVUASq3G2nEcCPjx/j3ZoTS5rHE3DkqDCKxrrKV0ne9C9/zlS6MdkrRaQSCnmHL0wQn7eZlKTv2wC6E7HmZFjCj6xYsPSeE0zc6Ic0YEAjdjzNOEohQ5Z2qt07SklE6nU4yr1ub29tnV7jblzFxynoVbLhmVdmE01kxzOhweLtMq3ILFXNKf/vlPfWaliID/ah0TAWFmYVZK1cbHNXdEVinEJiKl8RMK7I0ttZbK5+nCrVljCGla5t1un1MSkGm+NK258Zxyq5VQaaLGkmIsqFpriBBz2hprjc5NpLY+51aqtz4KmFKudlc/efduWua4rgYJtW7C2mghXFPywygAxlmlLZF6OM4/fH3/8srfXm2JsJQa10hEWuvLkoPvFOHx+OCt1dpOy9wab7ebaVr6brOs0+l471y321/nnFgWvcal7/y4GRXCE/7p/UYpBQCIUkpdluV8Ok6XcxPSyrx4/mEIobbKwsxtnqdWklIKAIfNXinKueVcjLGbUX0gLVBNma6vd1Emay3IjIAKiRDULzgZQhBAKCyV2Wn1hI0iQCpFIwAKCzxppEmk1QLakKIco9VGEa2xrOuyDwEZUklFmAWrcM2VRbw2tRRCtCpbUoSq63vmJiAMWLkGozrnCWnNiXOxoSNFYGxKWQO22lCac93uxYfj7hakxPJ43dG2DyICSLXkViMpdTxcUhOCUWsljEjEUrfbbWvcd0EY53ndjLvz+Xg8PoQQtrtn5+MP9XY7am2UVvSkVUKoNcfY1nUhhJzzvMY+hJubm9oAUff9ACAKMOdY8no+HxVgP2w22y2RSjnmXGpNAOS86op5H4/ehWApauPHjX441gZPDz6DNGFmVgqBOTVeqt5aVACEgMCtVmeMQsq1XuYpp+iMAhBtVO9cF3yrpdZmtJmX+dRaq23NUUSUsSgCRDFlACCAxpxqioWQVEsJByYR5qaUFkg774O1TKoiCkir1VpnrF5TBgCuxQU/bnalrCA4dN13fmkHKNMSr/abZT4LV+u709p6b2JcQjf4EFiklQKUgu9FgAjXuAZvjdWbcX86H5SZfLfVztlaas2FueWcay1rjLVWpdQ4bLzv+mEfQiBsb9+9Y46I0PWD0nqezopAERGp0PVK6dPpqLW11lnrH4+np4m/1Gxc6PtQtrt69Fbh0pi5MTOI0BPbjIqQiGDK7VnnDSUQQaL/H4OmWlvXhaVp7ZRSJZcmEEtFAKv1NEeFdJxnQlprI2nQmBRxa8KSSgvGlFbXlXujVQciXEsurfjOI8rUmEicUbFhZQERQGyNlXGIxEoVZtuFfghaqePxGIJvXAAAyGqlUkqAGPoOrW6tprx0pJy2j493AIJECJEQcqmH46ENAUS00TfXz97f3xul9Ol4v64RERCJSBlrx2Fnnev7vjUB4NaYuboQjNa1MktrLcMT3Zqq0tYYa4x/PNwjoIi0lknZPvh1mWquH3/pa5fLtB3Hy/k4l2ZICTcRBkBAFIAm8iTeF5FU29rEG60LC4sANAaFKpeyxlUhISIh/sLmR6BQ51a99zVFAJxz5NYaPHEwjVsDAK3UmpPTSimYU9qKWGeBEIXLGhFRAThFGqCUPM/TjXPkrbaaawUEBJFat1fXoQshdJfzqda82dwsy9R711pbl1Vp651DEmbnnEMEpdQ4budlRrQlt5ymJZYuhBhjTHl/te28tdpMy6QVuZubHRIBgNaqtUakEbBWzqV03ue8xJhCCH3fz9McnF3ms1YY00qovAvW+ZSiCITQpRxbaqksKca0nN989pPd7Uc5V2aw1mdwpDXwCvIL2ZOIIAICPFECmfkQiyWlECszPcHK0GJupValtEISFtIEIq22zXZcYiw5CWHh+vS2tTVFKpciCMhilarMDlQTaZUv09wNG9eT1rYAQm3MDUV6799O85ojETqlRaCJaObGrBXtnz0btlek1P7quuQswkoZYxQApFy2m70xbr48LPMSwe+2o5LsvU9VmqBCIG3X9aS1VcqM23EzDuu6aKM3444qi4ACUeualjnf39+JNCSaprmUAgiIapqmaZpD15NCEJkuU1zi0/lyPlhjp3kiUsfTMca1tYoAd/d3l3lSWrdWK3Nt1WjdbbfaGEUgIk9YkPz/0QgUltbanLIhturJKIaaiFt7chE9zU0osKa8xng4nQ7n86brubVcmtVGBBr/or8QoTAzArMYIgRoInPJUbiI2H4kTcwlLXPlhlpbYxs3Z42ylojQ6FSy0hoBxu3m069/q+vHVqs2pu97AVGKAKTWorVSmoBQGZ9L0pi9oWVdaqvyVGuBcm7ed1pbpc2zZzfDMC7LwtxYMp3Ppy+++HyeLufz6fM3Pzfa/pUQA1iYG7da97sb87T6hlBKMlr5rg/dqI3t+y6m1ZinFKezMaa0Ok9TSfF0Pr/44GNnrdHKe6dIDV0/7q83XSAA4SrMjaUyl9ae9mOjdG4Qm2ydJhCFolBak1wZEBQhIjaRVMppmpZ1vUzT4XTsnFeKAACJRACRnhbpp/ojwCJSWmNhq41ClAasLJNuqdQYc0xIZBTVUhWA0xpRxXkuOQkpbfSzD19urvfLMpWcCYEUWWNE2hME9KQCQoDQdR996atXu1Ek+84zMyEDcMoVUAXfibQYL5pkulwul/M8T0M/au9CbaW2GnxotbTW4lpKbiistBeQfugAsNVSci0lpRTHYWTUXOt2uxXh1goADH1AaM76GHNcU9/1h+NjTEWRctYY41jAGOx3V/tlOl6WVIuIsDAC1MZGkdXURIRlqryxanSqMlgiZi61goDTCkUaCBIpIqNUeHL9ktoOY8oJ4RcmFwb+RVUTeIKXU61OOUPQSlHGLPPCWqeSUlwdAWjTWauJFCpSIgglp5YzA3TOfPmXf3UYtykutXIuyTlnrXfOG6PneWm1IkLOpVZe11mYd7t9LoWZiRSSjpdTLQkRlYLOO+H2/v3blFatQxNDSOiM88G3VpYlLesioI6PD63V3KQ1AcCaY4przhFEtLFLyufLxVhNio7Ho/cdIiLBMG4ARSk01mpjXzx/VXIDeWotxXu32+xEW9cP+94bpTUhCORaEZ+8IUCILLDmtlYOzlmjiYgIaquKMFintSEkrdBa7bzzzgfntMagde89Ij1pgQlQRAyR00SIClCRctp4pW62m95ZRXi4e//Fz352OtyXlBHV4L3VutZCSEggzFwy5+X6dv/pt77tQ5DG1jildK11WaZSkog88ZrLMse4huCtUU/cy7IsOUci8M60lpyzWmvv3fXts1JbYwZAa+nh4b3msrphz1xijCy8392KCKBYa7a7IadUSm61llpybk6TUirNqevC9fXt5XwSwVLKZrO9XM6IgojW2s1ms8SSS3n77vPdfu9dd7W/RoTD44Prhu3wlbouxyWWVlvl0tpTeScgEEEQFilNekdWREAaizxtDMAEpI02SNzkMs1Om84Y4QrQBufKMAi3J3iVGRRgEzCaKotws0ZvxnG32djgBVsfnH/24nJ8LClpY7rQeR8aAj0ZIluuLXXWfPs3fuPlx19qtczTZHzb7XZaGxbOKcWYQGQcN4BApJdlRuG+Dyw4jpuS0xrXuKQudMaaWhpg09oeHg8gpJTyvvNIep4vxg3Om93u6vr6mXJhnnLfDT4EQM55SWmNMYtA13U29FSzMXEcNiI1phUAL5fTOG66fjg8PjjniYgU1soPhwMigECMURsLIsbaly9eHU+PE2Nn9VoMS27CIsAARoEA1CaakEWWlAdjmzRpIiIESNpYRbmJsR6UUYoOy7zGdec9cmUQpXDrw1pLbQ0bPlmXDOnciiJaU35zPDxO09Wad7cvxs3OaG2inx7vhiFQ6HOrT75Ybq3G1QF/41d+5Wvf+Wsh9NPliATOKgRYlhVArDFK664f4rI+MaytVQAFpAiIiLRxl/tHa6jvxpxXZuw6JyLLGgFl6Lc/fb86h3rYbHOandv3fV9rW+cLM2tnhHm6nJf5UktZU+77ARAE0YWeD0cBORyOAE+YlZunOXR91/UxLtY4ZkYou82G+742nh/fsohz3TiOX7x5/dOf/zi3tr+6SXzHzGvJuVajLQAAIBJarRTiXFpn2REmraxxlaWUqtFwq3Ncm0RQRICWC3QBhZ01jIpINMKTy6xgexqiaqtW0WlZqviHNP3o7vGjL60fvfp4DMEax2SMVjXFnBIAWuvyMlHLH37po9/6L/4Xu+cvlUJmZhFFujYptQ2da7WUWrqu08os67KuMxEOw6iUEsbGVYC3m8F7JyKNDQFobdYlirCzNouZ4nnjDe2vbhC51vrw+FBKcdZshs4601pJ8wQsSuv9/qYLIyCJkCJrtBau67pobTSJcJuX+Xi470KvlIophRDGoR/HwTo7dB0vD5wXpXXohs/fvDGkP/jgI7u76rquM8Zrw/ILol4hqif5NKnauDEq7Z9ChWstmgABtDYiYAlvNpvRW2Ge47KkPC2x1aKUcvrJFQGDNcFaAX4S7TXhj199uB03DKK0r2STELmu77qFsZRitam1ImlI8Wo3/O3/4h/sP/iS8d0TYE6kSGsWuUyT9c6FToRqbcs6A4D3AYDu7t4/Pj7+oqIihuBB0BiHSNY7pcyyrt55a50If/OTZzfboPu+T2sn/OTjbF03lBIVcpEW11kZa92ISIjY+b612rheXV/XWkPoGkutGbldpsNlWozx43D19t1rROz7ToBzKoDqxZd/+XS+aOeNMR9++GHn/N37d6W10PcxpSycay2tmYbGKK1Jk3oK01hy6Q22lltjrbUmksZTyoN3z5/dvnj50f3d3U/OJ87itWYUKBS01YoQVWUhQqttSrkJKEWCWGNcU3y+vfq1r3/LbbaHw8N5WQiwxNg5Pw5DK7W1VNP0S7/269/+zd8i0qHrQRAAtfEi4py+vdk9HQjnbCmr05SZc0pGO3bdPF9ijLvdVdeFWvl8uYSuI9Jd19eaidSyLtr5FzcbRfT4cK9FYBi3d+/vREhpLDWnFGtJOacm4F1nXch5MdY55y6Xo9aDUvgUiicMKfPxeCBlkezheNZa7XbX9/fvvLfWWm1Uztn22wGNdfbhJ3/58sVzAFpTjTkXQeVDj1qWlaExADBoIquoSHtanVpjUgQgBGC0sVonkT4Mpht/9PlPg+2G7dXdu9fNWq81IVdugVAZ2xhjbV6LIjIgLMKNIzcB/J///X/wwde+HueLlfqHf/QXwdmPnj8XBGNMF5xCDNZ89df/hnMBgUEYUSGRMUZESsnOOU3qEtN5mvaD15pU45YSoAxDsMZ+8fZ1a5XoeUo5xguidN2gjb5cTsws0IIPCFJr2oxbKqVo7aZ1zjm1KqfTwVgV18UoE/oNacPc+m4AdNNau64Xkfv7uxhTiiXG9MMf/TDm5EIYNxsiOp1P1tq+65ZlAoCrqyutqbWy3+9LKaXkrt+GMCCFw/E4xYhEcy1LrYIqi9S/oovhScAlkmr7BWcG8DQTEeF2u13WaT6fj8u6398wYXky9wBopYAIhS1hZ7RC0qSQpZbCCPen01/7zl9ftPs//1//4f/pv/4/vn1/Z5SucQnBG2sYBERA+Pbjjz795b9eS26lcGvMjVn+Ki4CWpNcam6SS40x1ibSWom51saNnTfPnr2wxj883K/r5KyLy5Ly/LTUcpPNdgOSYryA4Nu3r+l8nljkan9Ta3p4eDddjvO8aOOU9esa12U+Hg9PBv7WOITuKWtK5AnB4dvrm+cvP2KBcRitIUR1Pp+dC0q5ZZmstU/OA2Ze1/lqf+utqS2fLmcr+cNXH1RUMRdAJKVSaUstgqDpFwbKyi03VoRPdlSF0LjllEYfPvn4UxPG6TIprYLrCIkFBMAo3fnOaI0gTpEiDNYCKQFS2j7b3XztG1/TN6/+q//d//5v/4/+8699/OlXvvzVfhiU1rVUqdVrZK5f+42/dXVzbYzNDVARInBrKeV1uiyXszACgCEYDFirlTLKeduFmpbTZX44R0EYxj74vpRqjBm3+1brdLmktZCiEELJpbWWYr67PxIIzvO82+2GoTMkCJBzQW2WZTncv52nqeQVQLgtu9HVWs/ns9bOmMDKkdYffvjhZrO9ublBpOPx/ou3b16/eZNS3my2T1+6D945e74cjDHG2pJXEUYuL25vtDGltufXtx+/fDH2HShaK08pEypEVIQomJsQolbqKfbZKmUIWmvX26uPP3h5u9uSdVpr46zI0xQFjZtGAiSjSAHvvNOKAODD2+e/9o3v3Lz64Gd/+ZPv/eEPv/61X/rGr/5qPB289URU49JKCcaEvvvqr/4aMItIzMVaX0tlbkSolDnevU1xQcRg0VnS2j7hPdaam5t913Vv7+8aN2uVtWq/v6nMyzKJ0OH4OF3O1oDT2mhVCtwfTq8++IBC54EL57gZxpvdbrvZsgg3IRQfgrWu8/54OqSU1jWez6ecc83ls89+EuPaBYeIhORdsM6M26vgwm67uyxLKbXvtyklFMwpIWAXNkRqjjVmfvXi+uUnX2GAIfiPP/pov99bY7oQSNlzLE+aNa+0JapNUIAIRLgxE2Fn3dvHu3w69MG8fL79+Wc/dsb1ocNfFB9QIgzgnfHGWeN2wQVjSdG3v/Gtb/zqr/34i8unL9ytfqOUjo3f3b3pt2MpeU1rzElpvb2+3l3f5FwQpQuOEC/TlEtVSg3bvem3McXj8XFdpuNxWte4rmcRts5p13lvg7Mx5ZILkQCwItsaP1V/htpaq9xcsKQUA/lgdY6XvF7SqhAgWFsq19I0oe+2gjqnVZmhFg7eLMslpdSF/nw+rMvx5Yvb4NzxtChPpaTKrR92zloAuExLrQmErO0Oh/eEsN1cPTzeI/DTs/Dqdqe1/vTTL/dd563LJWlju55yu7Sc1lZ2xmYSAW7M5QlZYEAWQ2itvnt8bOuCl/Obu3eWLNTorcFeddZoo53WCLC2qhGtcgwwdr4pdXt9ray/u3vY787jlb/aPv/hH/3bUvL1drPOadzundHeuf2z5z6E4yVxXoa+R0IBIFLMklK6vn1mnVuX9XB4uHt/X0q6vrkmpBynGBOS2va9xlZrK7n4buccKkUp2sZtt7uJ6/z4eBzHTdf1iHj/eNCX02FZs7FGEayZa4Obm9vz5fL4+KikVWalO4D0V/QJKqW7fkMgpFxhMdoua/bOGW0F8DwtnTebcVAKl2UO2k1aK2UaP8Em+PFHL66utlwTM19f3SJSy2ld12mac2neGWDfWAioMDYhIFFEKAiIU84vqO+Neiv8e3/2J3//N//WX//Gt9/cvf29P//Tru8rKo3kLVqtRaQ3OuZijKWar0O4vro9vPk8Xd/+T/7Wd85lff7ylbT83d/97eurq96YSitocFqT8P7FCxt6F+u8cqmNEJ01NTcW0VpprQAk+JCiv3n23BoK3XC6XOZpGvpBKVaIWjtAOE+Hhub2en88PHRdl0uNcdVaT/O51hqs8VY7Z2mel2VdWciFMcb01Oud88B1Wc/otk1kt98MfSfcnPWAEoIX4MOlLMULmR/87PXbuztF6uF0+dEXd0ts1hgQ7MIACMYYQqq1pJwPp6NSdLUfQjc4563z1nakrSA+f/EiBDv2vXWhghCBUqrCU04haCJEWEqeUu6M9prenR7/H7/9r//J7/z2D376424Yhi5468au22/3mtRTzL+1ttXoDe6G/tl2W2M8HB8+2NHXXl6lx7f/6B/+15fTQSuFIqSk65xS2jq32WxqrYrQ+t74ACClNFKaSAE+QatACq+ubz/48IN+3LGAs1Zp1/fdsizMVQSfApJbWXKaaq2n82MIzhoTUzTGLfOUa0KizTDovgs29MaGYbNd4yIA0zwZbazvdX/VjdcBo/ddSmutYgygVEKrjFviRRvPkgngsqy79eIwf/zsSimMKfd9V2u+TEfnutqkMzD0G6V0P4xxjfN8jHFRCgjau7uDcf766naOpcRLbaJINBFA0YSlSRPpnY05I8D783zdB0uktTpd5vOyfvWTT1qugJmU8m7o+w0jrjkZY2oukKp11vhu3O1jzA/n8z//F//8eL5MKZ1OD10IwQdQhK0Mty+1wtB50Ga+XLz3MTcWYX5iXUJl8c7/FfxenOuZawOaY/aGbm+unrZ0pfXlciJSQ+eUVjWnZV4EodZsjA2+W9bZOj8vCVCVUnS/2eWCtRVrXN8Pl/NZ2LNIP2zI9U4jiWqtTtPFGFfjpK0x3Ri6jnAZPWvVfeeXvnI4Htb5qLX54NmzUhIAGm1KnoGlcnM+1FqVMtvN1vn+/nDUWse0agIkHIZxs/Va2dDvBu+vtrv3n/2EU1RP9C/gIVYWQQQiuqz5ErPWCosyGlHh+/v7WsumG/oQrsYtAPR9v+Solek6U7ABixs2YdxhqCyyIl1yfnh8QOCgTQieCHtL2+evvPVGqZcff2kYNyDiXSXCp+yH1pqxVkDWuCI8hS4yADmrQaiVIlwaSy5lEzoA6ftAIGuMIvJ4PL764NW6RkVqu9vX1tZ12m6vl2XKOellrcxIhOuSujBezmcARqRlufTApELjuq4l5+JdiCypgcwXa2zwIa4pQ+u6TXK2oDfWcUtEEnwv0lg4hGFdkyK1lDX0XeddytlqhV5vN/sU47BBAeo6ezxenl1fiZRg8OHzn7bWLOEEIgJLLtyYkAgFEOZctCICaMJQ4Zyn4EzKiQByyUYprbj3IXETbRBAULGIIPrNOJ8v0KoiAOBlXbuhI27B0TzVm+cvNl2w3o/bvdam1WKMNsYKM7eWSw7BigChBkQhtU4PJGK7oXJDUvM8O+cv09lq3PZhjUVrVaogwPXVThG1BjFlpZf9bl9ymeep7zfT5ayny3mal2EcffDDuNvv98uy1lIOh0dntVJBa31/f6+VrbVY302pns/x+W6oIjFlENZ6LTX145a51gohOOvs5XJqlY31Kad1Pcc1hdCVRjGmPnQrYU4FEYjQ7FTMcV2mq6ubzTi8f/c2l+wR1BMC8BQ+/GQmANCKUm773jwCAogwkyJSSkCUwt5ZZawxZjPSeYkozDlp11lrfR/WJtqYw8Ph/PDQaWODeGd3V9uyrmCCM+pmN2pLhet0OT0FHgNgEWaRvh8RQKEwV+tcY0gxluWsu5FBcaspV2Pk9mpX4jqnfF4aQru9fVFK8c4QIZFBxFYLAPR9d//wcLpMwJVSTjHGOM+EqpQcuh6REWHohuAH5/yT6g1RCTcBJBO09aQtIDlnh2Gw1o7jxjs3jNsKyvvQWl6Xi1KmVZ7niVvt+6CVevPuLqWEdSEAUtQP/f5q3w99jHHcjK9evAjOHx8fUkxV2ChEAER40qIQIiACUW6tM4YUMggq0kRPXuJaalrnWiM3ETJ9PxBXMNb1vQm9iDhrnFFpXi7zdD4/Xk4HLEkpONy9FcEf/Id//fGHrz742jeFBUBqrcsyn8+naZ6V0l3wpDQpTYRxnblm9JukNwAKBO/v3pQ4p5yt60FZNIYIzpdzE1YaAYBQOWc2m+FJpeC86ftunud1XfT9+zdEljajNraU2nVd33W1IiIu67S/2sRYEAhAUJmU0jgO94fpt7/346+82t9suxhnxGCtW+aLc+56Ozjr5+VkrWchQNls9ooUAMzLrBURScurskPoAgLWWhhkHDd91xnrfvbZz5fLKaVsnbUaEaQ9RSADEqESIgAipY3qjXmS9xIii9RSgvfLuqZ13nYBSXErahgEOHSD0VhzhtZKyUPwJc2VwVtjFQIzMzDZx/enmxe3v/Z3/6eIpLVzTillREQpVWuelynnbK3tuo7Z11przZv9zZNOiUhPl6O2vooh3T3fX49j9M57a3OeC0NvjNa6tYagjVGIpLT++KMvvf78J1opVEpt99cAUguLwDBs7t6/E4EnV888T8s6W9s1blqhlhwckeTO6cZc0qKUPl8euy4Q0dB1TbjmjKhEmAiYW60ZAEspwcHYjyfCFlcEqLXO07LGOvSDMebtu7fzNHX9kErtjCYgTaQIC/7iVhIUJAKtCEV6Z5ZSFBEhtdZqq02YACQVpbRzJkcARYjkhgFQee+biDSDCLeb8bKuRinfdaSUG7ZsAlM53D2+/vEPus2otQYQrbTSJCJK+Sc+IOd8Pk9aGwDRWgfvkKCUHMad0lZblxkUUUpFker7LpeklMEKOedcigjkHEMI0zQJg9Z4dXVL/bB5/uoTF/bHh7fzdD6dDs4PMT1dp6SXZUkpd13nnM5xLjnGmEZv//o3vxKcvVzOzgeltNbKWqu109a0GnOOa1prySCAgACYczJaW6NSSfO8GG37biDElMtmfBIqzdP5sB17RKyNG3MVRESjtX6KsftFF0ARueS66RwSCQiAAIJRSrgJs/GOGESqC0Er6q22hC6EUqrUqjWFzXbYXFnnQnDXN/uWMmhdn+Tw4P70d/7D8XAUQGYhIiJUClOKKSUi1XWd9761erlclNKNa2sNAQlAaaVIOsNWcS65tFJbskYZ22vtmKv3vwgrjTFeLlNal3WZx82GlPbDsF3Xy+N5+sGPfvz567dKUzeMMa0gcH9/V3IzxtRatFLDsIkpLctEUL3vnHXaBBHo+54QnXfMteRobadIa6289wJcaxHBNS4AkGIcuw5QYooikBuGfgCi8+VonQ/D1llHhEuuIPyk1PsFGP3kqQfIAocleaW8MVqRUeS0tkY/qakRkUiQmbkBlxRX6zwJOO+cMcvhsS3HkmanzbYfxu0211JA51JLTqnW8/1diWciEpG8HEteAch7r415ultNKTUMw2azyTlfLpd1XZWiVmMtSSs0mrWmx8e7aV6GcUfApdRYkrXOGutdZ61flrnWkmquYEtO1PWbVpOhNkde16wVxZhevHi52YxIuK5rLklEHg5HADbWAkjJS5oeUpqte7rj03Zd71yw1s7TucSktOr7noiWZV6XKNxKKSULoXP26YoC99nnP2FpH7y83Y5dSlEpvdnucm3GeWdMqg0B9FOSB6EgMAsCEGJtLeZSWxuDM8oEZwihMntjldYipAm9cxoEAYwLxhilFLIwN2tUni+tNavVdhMQGI1PVXKppI0QrTFP56NCeTKJIKpSS2sNUQHQ67fvAZ582Nl7b5xf1hhz3u2uh3Gbc1GECKAUGW1qFUHDzKVURBRQgjLPyzyvANL1w5LW1io554y1RDh69dVPP9qM4+VyAYCr6+vz+cgszjmlTBc6Y7v3774oJRqN3bixzhnjELCWXGsNXSfCrVXfDzVOGmrf9db6cdxa43OFVOW4NFLGWkMICBTjer3fMfPh8aHvBgYAkHGz2/RdqrUAeI0GgZAI6Uk8LCDIkpkf1nXbOWOU04pBUCCVtKxzTAsCKxCrwJD2TjcBbY08+YpAuDRL1FrZ7cbaZI51mubL6QSApFUVevfZ58vlkZn77bU2mltdpjMAa6WMViJSShGR2rgP3dVuLyzzshAZFpinWbh99NFH1/utiDSGWpK0nHOZpsuyzIfDQ85pHDfX+91V71hAe++n0+H1j767xPLJV7/t/PU8T62VcbM5nY6K1G63974LPpTaWGrX+S70od/EWGOeCSpAJbLW2mW+pDVWG0K/my6PZGC73Rmjz2duMClioOrsWGu+TOebm2e73R6JjodHBQQACqCsS9/1V5vxZ+/uD0u+Ds5qKo3rX6XaNBIUEOaYGg688SYXRiR6ahGooTUENFaXVIGrsp11llmU1qUmaK0bfJZKrGzoP3t9v+QWS4nzMobu6vr65vnz8erWdhsRRMSc1lq45FWrK9OHG77KpeRc9FO6Wsu5pKHvUsr3j3cKkUUOh8OGxdjeGGo1kZLgvbUekI/HU61Za/JhOEw1sTIGNJE5Xy7L5Zxzffv6Zzo4rdT19ZXRWpFhBmb4yc8+m6dpM/bX1zvnfhE3LtyMViCsVQihA5D5chaByzT13dANV5fLAbh53yvtGE1el9P5FNdzStF733X9OI6Xy+l0fACoQ78TgePd/eV8dlo5rc9r2nrnjQEAoyXW1ppoeWJrkEFqY6PUuhb8BV0IiKisVUoTEjC0mj16rY0YL8ytIZSoAIxWu2GYl/T53aPvupTy28eHs3kcnH7+69/55q/8GrOUUkIXchVEDaTv7t4Nw6aU7JzXWo/jyAK1Zud8bdUYe7W7vUynuM7LMi/rvN3djputtNx1Qy7Vh+5yOa5LNNpt9vs5prVKq9UQ0nd/8uaQcP/qU6eUAnbOX1/feu9jjALoQ69Ix4o/+eLh9ftDbZxz1tq0kpblfF4KC7I0IojrkmtG7axSl/NjyiV04zSdL+dHRTz23lgzDv0yX8Zxu93uNpsNgNzfv+uHQTs3X45D728/+GBeE3A1mjJLYREQRHIKLQILO6Od1l4brbXVikWQAFGGLnS+241DMEaY12mqOcZlWpcLM5PRfju6flDWt1IAMAT3+t39JSbOJac0r3FNWSmcjw9P8UzeB4QnkaNS2l1Ox6dRwBhjjCYiRYhAtbCITPOZpWw2G20ss+Rca165FWe9It11Xmk6n8+Nq/N+u9ld77cf3Wyf7UaurP/sJ599erv94NVzTfjsw083+2dD5xDxeLh7agAA/Mmrm9v90HlrrWstOudTKt/78Z3z3bc+vnoaD+d5EkGlNKtitF7WSSkzbK9Ph/ci4rtx6HsAUKgVggu9MfrtF69zTFr7/dWzw93r4+F+3G5vr3fvWjOKMLcp5ave1SqCZJTygAoJCIEgaK1JxSaIeLXbv3rxqtN6XWbXD6R1PD+UmteUBMDNx7LOGmnY7XW3ocsRJRLhWvIcYyAqjRnE+1CFHt6/bi0jotaaGXIuINk6++LVB33ft8bH46P3gRsLCCDEnGuO58spBN91/X5/XUqrJY2bvbWOWTSR9+58Povwui5dFwgZEGqtOa85Jf2tT573hsi455/8krE6rUtw+vx4uLt72G+vmfPj4dD3Q+/N48PrzbjvN1ciclzK3Tn96vP9MPTWWm41paiVjTFqRQLAjK0la812//z+/ZtSa9+PzlnStMyTcl6ET8fHq6vbJiqu6+bqxdvXP9miHvoAwlaR1bTk2lsdrEklAyELAgIp0og757V1mhRUAWVSzMM2dNa11pbpMp2PJed1jWlNkf9ySYVzunr2cv/Bl2qpJKCVBsA1rp/NZwNArXHjWNrpNImA0vrJX9UY7x8OH314G0K3rmsIIcaVSD3tHyLgvZ9rGcfx6XZtRBqGHnGYl1kbO8/rZjuI8OPjYynFWfJOny7TOAy5FBDcX1/rj65HQAneO+cRWKSIlM8/+6xWUUbX0pQywzAiYNdvUlo63ojQzab/W7/8pcE/3WYmy7LUWo1xzKUhMYuzXmtTSjTab3a3d+9fc6u+G29ffJBTJFLzdFqX6ermlQJclqk2NjYcHu+H0CnjFEJvzJTrYUlXHjqrgVsPJjUAQq9N593pMhXgkrI1hhGXuDpS1nfz+f3xNLXWnjx+x8fjHPPQh+ehU9Y4q+pa8prWVGptUtLVZgTBy7qcLyc0Q4x5XVal0Bif4tJ3hhCXZRVp1nitSClqrSJCyRUJmMtms0Uka+2yXESYmWrjL754vdnuFenL5SIMtbbtZquQj+dz5x23uuascNA//+zHr159CroXqUjofXiKber6ARCQgARKSbnU2kSbDlE9PtwdH+621y/GfktEzLwsM4jKJTnvmQWprnEdBiUi83LiBsMwlrRO50fj+loUtLbM07jZi0hO+WnR6ser0G8ev/j5L+xhCNZohcgIvXeIQECtlCZirfEGTplSbqU2rq33VlrbDjsCfjie5hjtE/CEQMDaO2ft1fVN2F9x/rjevWPTZbiM47g146ubZzGm5YvPX7/9vN9+pQnEmBFhGMww+L4PRAqAiCCucZ5mbawxtpRijEYQ6vtay1O+eUq5lKyUevHixWefffb4cOeMnefLUzjMtCRtPPCSck25rOtyPIh+8fyDXNs6n/rrrTX0FP+QUur7jdEeRIzRKabH+3e903b/stRccvZWgyig/29Nb9IzW5Kf90X8Y44z5fgOd6i6VdXdJLtbzckQm5BlW7Bl7gwZhmFv/AW88BcjYMALLwxvvLABQ7Qos9kQSbG7a7r3HXM6Y8wRWmTpA+Qu80TGc57n98OMgXPO+0CpUErmgod5zCmUHwwJueTkffDBSSnNNEQf63bVDxeE0Wpz4507Hk+UUkY5Jaxu2v71YV4WDiSjDACcQMU5RlhytpJcEuQL5lLrqkKPT797PiGMnbXWBS25lhRFq5QiQrl51krnaFrAKOZKKoQxwlju7moq7TK+nl5KSQjzfl52N7d/8Ys/+O53f/fVT3+/W60IpYApQogSep3cBJ8IRYt1DiQXPKeSc8a4YMA2YE4KABmHaZ5NjElKEZy5u719fHz67e9+o6Wwzux2N8M0FUxfj5dxdl2jkZ+dDXS9vjleLoC85ERX1TgOx8NLyYkgVIAiVEoygGnyo00YyXUMbrteF7RFGAHOAGQaR7MYLlBV6xyKFDxGVDeNtRYjQBg45877lEq7un15/IYQEoOTQqUYKYVcoveorqsQrXNms3uDKUW4MAJQMIPrrB7hnGpBm92ebe7U6gZz9jD8X7i8AkABfOkvq+aeEyQpG3MumLfbe1QSJEC5rFlcbbYxhJIzpWzVNgbKPJxDSkmpcZp5pf/Vf/U//Zftf181XcmIUXoFfQEhKeUYnTGmbRogrNIMFTTPE8aYMW596We3awghdDFnAKIkSzGaGAHYbrcruaRovXMphbvbm5TSF5+/i7FM40UI1sRIFztVlWq0FFz1l/748okCXq22QOhVDyVFjTDd3X2wy3IdL8zLshirpNRaxhj7/uyDRwhbszAuMSDGaCk5Zpwx6zp16mdfpKZkMQOTVUoBMCqElegKypxzH0pKKUU02Wkah4JQyJlQyoDGlFHMmmNcsImwvv/yzU//qKpbTslv/vZXOf82p4wpizmU4F0MyaOEqRT1an9TouNKJTtWinw6XkqP1PY241hKRrj87Gc///Txm9PhgJg+HZ6p4F989RMf/GlYmrblgDFgIYS1dhxHKfjiQ0Fl0wgCuKqqZVkwBsHQtpWUFB/ctRFNGQk+Esrm2QrJN9v1+XSijJ/Ol7bb4hIlg8E5H9zNbgekp1ry7W6Xkj+eXo7H1/12k2PY1CsEFCEkhEIIzfMMwFVNGeNtW5WMc0F103DOnLMIIaUahAFjknOy1mhdY4RTQtbYWrWMUEowAZBCdN3WTRef4nmYL5MDDNvNzfF87vt+ngeEycvD987YiEABYYw5iFBKLhkBK5R2u33X1G3bMUaI4NdFJEJICfl86W1GHJObuqnqNWWK7W5MLBhzotPjr//+9z58AIIREJRxvdv/xc//6Pjp4+9+/dff/fY3RHIhJUKFMbbdrEtO4QcTPQHAq1Wbc3kd3X9cBqR5npumjjHFnCslESqHw2sIOQQLpDbWVxpiQdmlruZ1054v50qqw/GgBR3GKSQkGCmoxFKorlQpaR6Hh8eHm5vbql2fnz8hP1MuCpE/jHlzSQgpra5vFYDAarXijF6fP6iAlJUx86XvV12bCl6M4RSXDKjEZVlwKZWgIYSqqqVgw9kTXhEwhLKXl5dVqxfjD4fnx+9+22z3/ctLSinkEhFoQjiFK+IEIUjBU4wZpTG5kku32TBKi3cxJkD44Xj+dLq839/vb96jtktE5kRRCpHwl+NrwyllLKW0GFdp9fZHP2FK3e53/8mf/7Pnx2+meWnWuwKEc8EKitGH6FNO1z6uUqoUVIeSC8opPz89hBi7tk0pLMZWWnnnz+dz3bRCyFKQEEIIeasb7+M0j23dbjc3l8tlmscBEBMrIDg4a50TXFBK6evry8vTA+Nyt7s1ZqyahnMWrMnIRs+pqJq2yTkBAELIRxyjkxxXlc45T9PARbVedcP5mXHKhagKXC6nJToulOSMczWOx2ma1uuVkNLMl5iSW5YY891+RZD/+vuHu93ONs1JKhSzHXtGaC5hcN6nWDGqGaeEJYSs92YaCeGrriUUfvKzX/zf/+f/ATY47xe7MMpSDDrGGrhstiiluqq4oP3DxwVIo7harQsGxnndNfs3b401291uu9m9//KLZTZt10opCSE5F0oVxth7F4Kvqsq5kHOuBCqFxOjaVRe8//rr39RNu1rvKaGTH7XSnPJLf+66ddd1Of8AhY8hLYvpuu719YVQMi8jSYwz2rU7RlBBmc59fzy8Yky5kADIGRszCN2IVgczLeMFRY9zxJQjInBBpZR5XgimhMA8TynGphEhOIRyVTXzPHnv26YZe4tKHod+iWCsjckrpQgh1lmEYDx8Krxapr5tu/dvEc55v79nXLw8PcaSASMK4HNxsRCcFcepZECQClrmSTdKMGp86HY3dds9XyZUkPWeUUYzEsWDGVmOiBIumCCl5qgErO/eyGZVEITgqrZ79/7zy9BrJed5WpaZMT5NozGLUjKl9B8jACSEoJTl5AvGOaMYAxeiruthGNsO1XXNKOQcCSFK1cPQXy5nxigABoJjQJfLOcUgBQ4h3t7evxxe1uv9tDhGQTIyzcNmc0Ofnj4p3WVU9vublOLlco6ZOu/v7t7Ids9V7edLXHpEBVRdAaYlZbRDOcQUpnG4gtnn00moCgF5+PQJAP/oq58QKBhTQuhhWgCQ1lxK6b3JBZeCmarqpvvum98S2dZVfT4fjTNKVlJVqukOn74XlISQMcKpIJMyZQJhSlBx81hysTYKpe/fvPnw4fNPD48mlVxyxengw+js5fWT9YbqJq5ahh0uRRJE2n3EJAevBJVdczwfOePLYgCgqjsgQIACXGVi1FqLEMq5XIf/V8UmYwyjFEOgBDCG1Wp9jQCvywRjZ2Pmqmq0rsw8CilPZ3M5nxnFWmBEBAasFI8xVEqrSgMhx+PRhkITwimjuq66rjPL5GKs61pwbowtBVEq1Po2B2uny9K/UKaZbjjjpZAUkzULZfxy7k99//b2DoBijDEmxnrGNcGIso3UtqTMuNBaD+MRY0ZYWW/vdFV/BvD8fLTObjc7s3x8ef6IgSBMTYqloJISopBKSbnEUnDKnRSQy+vjQ7vqPuy2x9P5x7/401//za/AuZTSqtLOp18/vc7O3y8DAF63K67X+/2mpgkLeQU2Cs53d28oEd6HnIMQIucUghNCpoRSwgAYAKSU5eo3LMgH55yrqkoIZUYTY+RcBB+E5JTSZTHTNGGUt9u1kBVjDKGCMRESCsFEKsK1826Z591m/+233yBsU4la3a5X29ksNIQIEDlnGKNpGjjljLCExThZRskyjwC47VbVWrhltNPgzrOsV0K1KcUY07rZhFhy9kIIwfkXX3w5TXNMCOGYAX6YqTPWNK0PJvoYYqy0NsYuy0QIIwRLyZu6Xa3X3rt+GGy8kgERRsXFwDE13gPG67pJqVT721CKrprD8cC4/KM//2ff/N3f/v//5q98ysnOP/3szXkYn4OvUGx4JXd31eqGhEO1eWsxKSkAKu9/9KP17jZ6yxmxNthlqSqtpBBSppgLShjDVaSdYsjAKGd13XLmrDPzPHMuEIaUEqWMUnDOLcuSUlKqStHnHEJAKMdhOHebXVU3Kfics5IaMIsptt3qfD7kEE7HFykEoQAxZiHYlTpsl4kxWQAWeyVeFAA4fvs3j1//g/NFVOt6cyeUXIaTGQ9jfymoxFR8CJv1jgvx9PLona204gwI4HmxxvoQM8bAOJ3nqSBghFzVsYQQSslm3e73dwVDpSvKRAhxWSYTUyqZAEolh5RDSiGGnDxm5Muf/eLzDx90VSNEKGGMi3/53/0PP/39n64oJt52DP3hF+8+v7sjVWMBhuHy+O//reAoU56ip8ndffjs/ouvMMoEpaauuRAIKMo5LJOz7nh6zbmwa+JMSYphNs76bIwllNV1A0CnafLOlHIViNJxHK91lYJQRj+YcYfLiQACoIDwPA7BW84FIWRZpqauOVfO2++//5pQxriilVaUAufCWmONVXUFJbcaUir9OKyaOi+nwtU0LcMQmqatu3vKhuQXa3pGVC6FX+nSStrHYJihlABGGJeYSg5OcqKULiU5a4FQQBnlBIBRKaggIRQBGuMyDsdf/eqvhagWs7iYY0KcgADICOecUsLRW8k6Z6zSFUZQVxzhAhjdff7l//g//y9//1f/z9d/+zdh7n/+5duYyWU28zBUELfv97zdFlTaru1ub9///k8ZZ6UgzDhQJoSq6vry+F3MuWUaIUIpn6ZJa40QygWl6CSr+stJaS2VXnVrp/Try5NZzGq9opTEGK/TMClAKUUp8yGIak1wNvM5IK3qbp6GeTbeO2stY1zI+nz+XldtCOnSHykkN/QnQr54PZ9m62RVSsk5pe9fjoLipl7pt38iBLPG5uy9cwSAS75q18sy+eyLneqqxUAEZ2/u3gAlBKPz82+rdt81q3HqGQWt5bKM1991AepTSSkSQowxXEjAIDnxMeScKODL+VJKCQX5FOS1xVQQRqUmJBpzevlk3c8JBgBcVTVjXCnZ1HW72d99+DKFcPzm2+nwUCsm3t0KIYRUerNv7u7efPFVoVxpLaWajdGV5pxxznNOrtthAErpNE2MSwJwve5cmzwYXzUfJMYQc8BAbu/eLMscYzJmQQhbOzfNqpRi7SJ1+3oaaslQGGMIiHMp9OF1QQjlhJRqSil1JdfrtRDyfD7klGgukTGRUzTjKLgESgqGh4dHwfh+s7IhefVO0kWghDHNKaeUpFQhWOsClRohfJ3GhRAZF5QxVAoVdSzU20VwXlDOJc/zhDEQKAUL7xxCUEruVqucMhd8mhHC5P7+7eHhcegvKWcMEFO2JSBUas4EEBNTMT6lzJmgBBMCJWMpJcaIABjr1Obm3Yevyh/710/ffvrHv7f9Sei62d/cfPaF6tZt2wFhBSMzDc45Ibj3XghJCO3W2+PxFQOilC7LfHOzJ4Qsy3IFvXkf63bFKBunCTBCOFZV1bbdssyn05FShTEBQJTL6IwzMyfI+4AyANeM4XmaYkzeO0IIp8I64+yotS4lBx8WM1GgrORgnTXGMKarek0BBffdZtUwAOtmEDqkwiBrXVHCjTFVVQ/HT0JVTFQZIRfibGMlCBCgjFhrZLVdXDRmbCq5Wq1RQfO85IIJEGsnSoXgqqpVyTiEkHNknG/X22Ez/Nt//f/O1grKcsnX3CmkbGMEwHMqgtJ2e1PXlbfLMg1cNkCQGV3JuW6qzX5XVxUXYnt3J7rV+XRcdRvjFtW0VdVkRErJFAPCKAZPCS2ljONEAJWCYvAYl7qqgRDvnAHw3iGMMUKMkRDL8WQYQYJkVIq1JoYolZayNmYRQhpjEALOuPeBUTSNE06hXm8xwuf+3DRVyVgpfQVTUSoWM1PAxhrvDbSrTQrBmCWGSJlcpjGGsL/Zdd06I1JSqqkFQNb4eTbTNCGcMS7LPFZKV7UWnGAUMc4xhpxTSWkcBh8sI7nRspSilByn3hhLgAIBa20pkTGMC5qXKRdknfXeKlUzys7Hl5RSLgUjAABCiOCCUI4oiRhToKumxaj4ZSaYKCU/Pr/+9T988+++fYoxaqWU0s7OQ3/RVcuEzggr3SQMjOBSUn85jUMvVdc07TicC0LeO2P9YpZutem6DWVUCHG5DOfLAACA6dX7fBnGbx5fbEhCKlTi6fB06Yf+0rdtq5Qyy0IpizGaxcSQtK600jEEAEAoV0oBRhnjqwGyqqoUluCWeZ4JDk2zgt3uRkjWn0/WxRLDt//w168vD4yJeR6A4KZuaImKES54ydmYmVLinLM2LNPJjq84h6bWm7ZSSqX4A0BCSY1xTjkKIXNOx+OhoCKlAIC7u7umqWMq0zzGYHGJQnCM8cvzx6//8e8OLy8ESC6IAKWUc8a5EJWqBdOUVwUgpTjP5vjyfVXXGGPFSC35FfRf13WM4XQ6TdPY1HVd1z46BJgR4ZYJMPYhSt0cxkjVarO9SSFoJa/YMSFYKYkQwhmrtL6CwgAI4wKAUlT2DbXj5Xg6l5gFE1qrEJZx7BnlUkpnrTFmXqZ5ma2Li/Exp+BdSXGaF+NwiimFkAvq+yNnWHEa7aA5TTECELZq6vPpdRwugLyuayWk836eR8mhZB9TopQJLpx3fX/CGHu7CKGqZhu9nftXN58RzoRRIQTCSEpWUOFcK1k3dUOAoFKUrIDAtel+bYcRIhBCdu59QM/Hcej7j99+PS/mmjhdv/4AhDLGpaRcCikTZSEYxqlPyDrrxuOmUV/e1P/0p1++ffOWEHh6+phicc4Lpba7vZRSEhyCCZhQxgkQjOlg8mhL23WMc0xAcK61Tim/vh5KRsfjKxf0zf2tcz4ERxnjXFJG39/tCOToDTBadWulFAEIIWJA683GeZ9zrHRr7bzME2G82+xTjCEEKTjgohWTSjo3Y4wYk3Y+cYjterupOeSC627rfVC6prJZ3XyOgBBChZAYQy5lXqZpnnMuSsm6bqSU4zhN1oXMZHvTbu6t9Y8P3w2HB0CRMZpLHoaLs3Ycp5hSyinGyLm01qSUrpXKGJO18zLPIWVKYb3qhKw/PX66to4xYEopZ5wyCphgoIxxinAOeelHgmF79x5jmPtXMw/GBq0456zvz1fLhFKKUlrX9aprlJJKSi70NdQMwVrrpmU5nc455VKgnxatq5KLVjUhoFQFV9S6986ZFLO1pu9P1rm26apKmXmw1gohMCEhhNPpWFDebrcANKZ07aw0TSNknTIKIVV1pTWv65WzS84BMDu8vqaMIpaYybapoRSEqKCUbXa3XNUFk3mazw+/YZRZE1KKpeR5XlIK3vvVekOAWGeneXl8/jhOC1C12b+r69Y6cz48mHny3lHCU44EUIp+nqZ+6H1wizHn84Fz4X1AKOecKePARKXFbt1SRpy1uCAMGAihhGqlCaEFIQDIpSzBex8uh4NzXlcdYdIlMi1O1TWh1Hs3TQtGRHKxWW/NFQgKFBMWc8o5/rA8ZGyl8UpCjnGexuB9yihnNI0nShAAwhhRwlApJSMfQgzx8PxRSwmEUMY516fB9EMfUywFnc/HmLKzRinVdV0IXgh9Oh2jd4sxz6+vIcYYA2Pycjl7NzNKf/f1byczF9YAbxCiiSqKMTLL5L3jgpeCKODZ98PTb3Z3X1jsCEUYY0IoQiXFTAjxwaUYlGooY6WU8+XAmZCyVbp1djqfz4tZ9pt93dTGOGcmG6K1PgW7Xe/mZXHWSSk363VBueRCCMeYGnPq+6NdDAZMCb323QmGhBAAJoCcddM8JUqiM1c0IiG03dxzQe/fvAXAT0+PzkUUffHHUslQpOBE122KPqZICHgfcglmmWpKFArW4IQRYXyzalPOGLNccn++1M2aC34lbwJAjCEkvGs6hMH5zBjdbHbTPJ5OJ4QKBiqkHPoBIdBazzOzdgFCnTcYUSkl4zxGbMxlnvvtZhWsV1JQrgmhJeV+GLbbDWCMnFkoYZTSp+eX59cnVW/e/fSfIyBScq10ioEzQqlgjAshnZ1jiFxUjPEYrWCsJDeNR++crlb3959td7fz3J8Pj8EbwniMcbe58c7m5KWQbde27fZ6wRqHo/NuGC4AWKsqxpBzKTkTAMZYTNGnWFIK3vXj4IKXlEAKpATJSAqm0rxpmuveYZ6XnFJeXlBc5mmgpFi7CKEIZVVVYwyUMh8iJiQEa42RUlW6vfLbQ8gZ4ZSRlJJReu0/pxIRygClaqqcszX2H7976RdXVTVGsMxLQbBab5uqmRw8vpxiTG3bARCt6mWxMbq60oypZZkQCpyyy+F4GUelV5ypSgp//h75yVkDAHhZFsY4JVQKpqXKiCaimBCllH44z/OYkovRp5Q4Y8YsCF0hnYwS4dystGaU+eAPx9d+uChZb/fvqm4XcrLzkL2nnBMuuJDXg7WuNaUQ+0/ITEAAqCAgldJC8hhTTAljHHzw3paYrPPTPBvvtOCbtis4j8MJADOhgjVCcGvNMA4EGEFFV211+5OCubPLMJxjDNd44IpfZlxSRoEAFgrjRADmeXLOpBgoZUrpuumcdyXnEDzGQCknQLWUCGHOeMHF+Xi+9JSxpm4rVdW68iFxzgDnh4/fhODbdh1TmKbeWqN1E2JgDAEGM4/DPAFhJsTR2phTRGDM5KwFlJNzPuWCEMEIO2dOw/jtp8drr2RZPOMKIUQIvca287TElFO0dukpBSH1MMfJM+9LSWkYhsvl7L0ByjfbG0ZwjIkAbdstRsQt4zSNpZQroLXa3AshGdepFKF0111JVJkSErx1wbsQ+nnspxGVLChzwa3v32z298N4JJSA0BjI+Xx21qUU6raT3RtEa1XXlAkASDFgDJwLAFRKKiWlmKTWIabzZbmeVRgRZ00uKIR4zTiv1DVKGaXCh1gQEAI5h7cbRXIwy0wpIVykUgjgnMK60WnpT8+f5nmSQlLKcy5Ka4QQg6gE//jx+8ksmHAlNWfiirsyiPFqlTMCa2bjFsBlmKbJ5Uo3OSaKkXM2RM9Edeln70MuqFu1zttxHEKMnPP+cuyH8zwvr6dlmNJVvapUgzCd5/nw/EQBcsEFoarWCBVrJmfGZZmPlyHEhKs9FSp6X1KQArquub3/jHGqOJeM1lIKSifvYoickk4JVHLGpdvetKudVNX58CSlyrm8PD+nlKWQMUXrnLUzY1dNAKVMpJRcCJxzSpm19nK5YIQLgpCxc8F5W1BCCOeCvA8xZGsXIFByjiECkJxzCMlaG2Nqa4lxYYxLLvpp7hfvfUAYWzMvLtbdNsby/PKgtbp/85Yy4UxPULKL4ZxL1abgc7K1opphVMrpeIwxUYLBGmONu7Z8R+NDQptVu9+2UirOxHmYXw5n51wMnhCac8YFUUoJoXWzbpv1vMwUO8l8yT7nzAVlpBhjKaWM0WmegVJKwdjZ+iiqrmna7bpFGDX1Kud8OL4Gb7wLNzf3f/Rnf/6Hf/hPmkpN09xWNac0hrCpqy9v91/e3FSC6a5r9/fTPK3X+7peXc4vp+MhpVxyRkDP41w1K4yRc4ZgxCi31s3zIqXGQI1Zcs7GmHlaGNep4Ien5+AdKklppTgjJCOEnLMxphhTSunKrM4pn879ZVw4F0IIICQjklNO0Y9mMWaZl5nrje72GGdjppxDU1cERUBpmk3IIGRDmWo3d4TKGAylJMSodaNklUuhPvqUSsaFEti1KqcgmBBCOe+MmVDJXVMzxjHBAOBsQBgJUeeMuOBN0zJOg3OUyX5YQqRAfEx2s91opXJKzvu67QDI6Xicp+lHP/qxriqESkplcfOlPxtjuraklG5vb37+85+R7P+3v/zL19dv57pmjHFKVk1LqaCEvH3/7v4nv19vbpfFAMbrzfZyysfTMWccg//06Wm97qSUxpoYYkkREDqfe+fMZ599hTEBIJSSqqpDjOAXglKMHgPmnFd1VVCRiedcnJ9TSs46QmkIDgOZxv7p6UlVXVzOsqoL5qUUKIEgOo0L4OJdrGvNGANMOd9TSpd5zDGcLwPChPAa4zQsS57D240mhGMgDpcf/fgnKeFhHqHkQii5v3tT181+s6oriXEJhZzP58fvv73ddu/evkEFJWc459bOCGHOOQaQUpeCL+fh0vdc8LquKi04Y1LoFGJV1zklSlhO6HK5eGe8mRCCZVlCCBjjmHxKnnMRU+i6BmPEGP3w4z948+4+lzRbkzEGIKmU5/N5nPs/+xf/4pf/xX89DMNss3NRSE4pKaUgKLqqnTOcU+fT83E6nQ/jcAaUu7omQOZpAoD1eq2UEkJgDMFbRvGbu9ubm33dtDlHZ00Ifp4GjLAxC8KFMSakVEpTzqUUGOfx+BDnY9e14zS9vDxfzie3TLXWum4RKpQULsSValxSOF8uLmagKnhHaaklrZUoWNqAMdDtZu0CfjzPSjA6DT2jTGkpJB8vZ0AFAaYYz8Mw9peSQ1yOlEq+3mCMnTEIY0IxYXA+X3JO333/reTszdvPcg6CU8aZcy4XRCkf7BFhWlCJIbx5+9nQXFKOHGjOJSWrVFVVzllXSlJaxRgIgfV69wc//8W/+dd/hRGmGGNchmUWALc/vv8nf/rLqtu+PD9IBk1bI1ROp2PKSEpSV/rN3UZr0c/GBnBz39y/oVJjDPv9rXe+pCiEcE5M05RzzjGsVu1me5NSGMeLMSbGjDGmlOWCnHNa11c5Nca4qir29q1zwbrH5GdrPcG4bdcfT6attVQak1QKUEqdtX1/LNdJqI9Nu0qpAABjUDedNe7vfvNbqdSbjZLi3cfDGAn/qu1gXhYASglhBHwIfT9QKhWDaRmMmVMIcT6E6YkyklIIwaWMMEIFkZTSNPV11Wy2e+ejcXExdhhGjAol1DtvzXy9x1LCKGX73S0hGAAOr8+nwzGGCJgQAldaszEGlQKAf/x7f/Du/VuK4o8+vP3s/fvZLBL8n/7Jn9RNk4IDjCFbychwufiQuJRNs5rmUSvOKJScECpdt2vaNSEipkgZCyHOy3Jl2itVMUalVrqq+v58OBysdZzL1WotpVqtt5vNtmmarlsJIeZ5nucBY0Qpzyk223u1fns4DT6EEKIv1GTez04Kwhmf58W5ed02BEg/DJzz/XaHSuCcS9k8Pnx8evjGRESFdm5+ePjWR6Q4S9HTxdhudWONVboCQpd5qJtWCvXu/Rfx9k5UmuDPnQ8lpxhDjAkw8S4wTKUQdbsVaibYj/2JcXk4Xihgsmql5NZO0zgSVs+LqXRVckkoIIRyRtZ6AjCOp5IQKohzwTg7vj7bZYnZvHn/4S/+m//2N7/6//75f/4vP7yc/vf/9S//5I9/+uHLr/rDE6+7jBCjrCDc9+cQYt3Iplmfjk/LYtbbe0zSprVtVYfgC0LWeA9pcWZ2vmnb6ynKOWeMWmvn2TRNV0r03i/LUgoOIYbgtVJcyLZdl4KNWQ6HQ9O0UsmSOYAWbOKcIBQ3TaO1qhQtGRljrV0YzrOJESFddzF6yjBj1DkTffz23/87Khhp3tqY32zuT4fvFJMSO2MijSkTygrC1/Xl7f1bpRTGcHf3LiVLCU2iZjQxynNOy2KreoOptNZP0yTbe2BIAjtdDjkDYzRl+Prj04+/fN9pXUoZxrOuOiE4huy9994xqjfbmxhMKQgY5IykEozy6fRMCfEpYUL+6S//07u7u9u3HzafZYzKn/3yl1IIzAXnYtWxqm1zTv3lEmMEQN6OjDHr5nlZGGP7dTOOw5Jc265TjC7OdVVTKr33nFNCiLXWmCWlrGS1LHMpUUqRc0kpXs4XITglJIQ0jVOITumKcz5NY103znnvJimAEqakqimrKlwpdTicQpijW6ZlDhnX3Y33S1U1GAGlNIRsrWk2Oyk4bda+gI854+q206UEDEBDjBihbrVCJQOwkEJL4fn5UTX7ut1Gdy4ZJAcu2DT2ISapK8ZKCEEpWXIUDFDOlNKEaNOpGOI89wA4pYAwolQAQdN04ozruoshz/Nk7PLdd19/9v6Ltl2N41DVuuScgAHF21ozikE029v7brXp2tVq1Va6ShkRwLkUQighEIL3MRJCMcJjf8wIKKvHcbq9u00x5oKFqFHBhBJAjGBy/UhV6RCi9y5450M8HJ5ubt8hLEoG79NVY0QIi9EzVpWSTseejcuXX35ZUnp9+Pb+/Zcx5uN5mN24X7dQEqVinMz5fALsY/A2RKB6Gq+o3I0PUesqp9L3588+/J5SXAiVShmGMRbQSlGicinUWX86nykTuqrOi4OC4sPHkBKa55gJh4xydiVhXKy1GEjKmBTMKFl1jfX+Mgy7TbNe7RazJO+tmW73W6V0CJ4T0LpZrdbGWe8tpaSqKmOWpm6229vHp0+EEmOcc24xS0YECLRtg3IsCG23e8Gw1orSu2mal/myqhVmKniXczZ2KQWUVlzWx3nRWnBWffr0iQAAr3rjOowQwkLwhPE0L9SH27tt8GGa5qbW/dmk9EPutNh0drOgVEq5Wq3m2ZTk+8EihDiXzrllMU3bYZRCdN5n66yQFS4JAVibnp+fx+GgpOCcbW/fm9k5M6acvVtKiVVVAYEQwvF83uJutdrGaKdS1t3KByuFds7TnDMhPMSUol/XAuXy/beX7e4+BVuSdwgAoOt0Kcg7U3IJIZaSOEVCqGG+DPPUNSols8wXQitj3c3NTV03w/nFW7sYk9xF6Y4DRskrJbSWBeWmaV4PryE4gIxRfn1+Cs5RoQhhgwk5OsaYnXqrW0woIbTmJPRHunnHCEghDocXSllVV5QRLiolpZRSa365HHe3utUVpyjlACBma0J0N7f74MPpdNS6woDrqsqFBJ/6vo+FA6FVVc0mUIYoJ7jIw9NDwezHX32GUQ7BOTtX9WpZxpfXp5KR5IjSlY/o5enTOJw5A+991W4YU6xhUfP+cj6fj1XdEEJyTozScZ5zaWfncf6hZ3GlD+cUaVXVm22zXu/maeIEgyBVs4rR22XgTAiIWG+EkKUU7xwA9m7MrmScOZMMoV3FAAgqSMhKa73b7VLy3ltrLZOVILSgvHjvl2m4HJXSTDVKNwWhu7ubFMvzy3PwPng/TtOay1KyWWaMf4Cdj+NQd2sueTTgEsohacUxgZxyiIEQ+sNLV8JSire39/MyVUoQUIRSY6YYI6V837Z1Xf3ud791zmMMbdtiQrQWizExeqkFweBDQAgNYy+4EEIpXfuMCAGM0Pk8YADCuBRKKeVspFTEiM6Xy8Pzs+b40+vh88+/KgWit8u83N7eKKku/cXYgPCMSiSACCCtKhto8oFQ4ACLy4/HnmRLpdSAxTBc5tl0bSOpxKiM45mgvKQUyryqdzkV57x3PuXsrCVCZiAfH58JYIWt5dXL6+Pd3VvOREk+xXw5n4b+culHXTWr9bpuupyTNfM8HPvpCeBYUNmsV1worSTCBQPmUoeQ5uG4zGdEVNdom4TPsCzGu4Vgord3wBRlaFkW7wNnHDC1i4kxheAoo7qqZSkYIJdUwhUqUZgQ6/XGe+v9D38CAANhPMQAhBAEOEcuKwzAOby8Xijh3vu64s758+lQ6SqVQgmJCWGUNpvdp0+PhIpxvHx6fHQ+SYp3+zspK04Rwtg5O4yTt3P2k+CVc36320zT4J0dh1O9aSIikjBGYBmm3sS1wIARXpbx8PI9ISjEfD5fqrqe5wlhfHv3rtl/yCghVFApMXgAMgzLbExA7Ne/ewqINft307J8/fV3PsTTZbj0P4ynxuEUU6KMvbwcnh4fnHWUyWb1drt/t97tdd0Y6x4fPh1ePsZlMPPIKGvb1ifAmHBGgIqq2SCg59Px5fnJ+SCULskDzs4Y5zwBHFOeFzcMF2tnIYSZ55RyzsUa8/D0NC8uZooxjzEcjy+Msqv5czELYxxjLDh3zk7TAIClVAghzhXjEggoIVftinM5jhcKBYCcxvl0OjprtKzG4ZJzaJVkOFLK727ftl1d11VKqWkq4/3kYR5OuSClNWeMMQGAYwi0eJQsQuXcj3aZS0m5FLqYmXOkpcKYjOOIcdRQ7/d3/eU1Jk+JwDgLKTCgmJNSK4RCfz5ONiWEdquGUdLU1VdffSUYtSFbM1e1ruoaE66YqOr2m+8fG2swghBDpXXKGWHQuhZCNqs8jX1JNnmTM0IIrHVKVUrX1lnAONo4zIvgAoAFH1KyUu0v51OMgTGSicxcsoJSjqfX5/H8ur55p6UqBSldTza3NLOKjMN4OvUYYcE4BjDGVlUtpQ4utG3jQ1iWhTJ56c+cS4ILF/J0PhMAJWXmMiQsALngYkmohGnqn14edpttPxz3+11TrbmQQtUxGoILFZVfTFXXqvvxdw8vSqa2rrSuMYbzZcjoWXBIqpoWSyheM5bcCG234kxSyghBQBDJ8fT6oLR++/4rhIAxyrnmXOaUc0EhharimEsp6H/2x7+nJX19fZ3Gy3bd9qfncXaoYKV0SjEhJKTKOW62WynrmAvCpB8uMcbL6fXl4fvD88PlfAret5u9kAqhgnCOKVnrKOWAseA0ljxa39St0srYBQBzJsZpKgWtt3vKVUSkAGnrehku58Mj59Q6C0A45zF4gmMleYiBUCaEbFad0rUQ4to8klLsdtuu66y1xsycciV5CG6ax3GxOaN+NAg4pkwKRnBBBRtjD8cXweTlcmGMK9VYO2GUg5tjSCE6523ws2SZC02BPB9Oxpiqqhjnl8vFOTsMlxgiRqUSBIVZKfkfAJJeR+/ocu/AAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<PIL.Image.Image image mode=RGB size=128x128 at 0x7F963E023B90>"
+       "<PIL.Image.Image image mode=RGB size=128x128 at 0x7FEA923F4760>"
       ]
      },
-     "execution_count": null,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -543,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,17 +554,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAAAAADmVT4XAAAK3ElEQVR4nO2a2XIjubGGM7HUXlxKXKTunvEaYb//uzjixJnweNyj1kJRXGqvwpK+ILV1j20UWzo3R/8VCyQLH4BEApkAwLve9a53vetd7/r/LnT+ISJDxhgyxMOfjDGGAJDIEp0MINx/KT0vCALP8yRHADB1XlQaEK3qu5PrdwdgXhin4/E4SZLAZwCg1l+u1i0xZupSmbcHkOF4cjafz7LpJIkYALSX/+vLkgRXOXVvD+Al02y2OD9fzs6yUcwAoE2tooIE731Sp3eBCwDjXMTZcrFYLBbzbDoNAAAgWmxLqEiwLhEErdLmJEt0AEDhB+Hk4tPH5Ww6GaVpcCyP5l3UAmPdbSjEvqybU+p3ApDhaDL/3R9+vJiEoR/Ix79OWaaBYTMNuFitqddvBhBPFh9+/OPvz1POgXN79AMsDWaECG3MCAVasz9lDBwAuJ9MF+cXF+cL71BgDxVxcRiMlLpWMy6CsO6NtQSDOP47AJPRZPnx43KaHOsHJAB8cqIsyVoIR/PtZr8vqk4bO4TAAcCLs4tPnxYj77EIX7pwObb+9GNRblZXV6u8ARgyJ516YDw7X0xCdnj+tnk84vFC9f3my09cG0t2QP0OAMhlGCdxIMAygG9eTgAYBikhmF1qyn2rzaDZ4GCE1hpjDBEyAGAEQPDc0BA4AAcAOa9nZ9Oq7/vXBbC6LffbyPfDY32HUaCHhyfxMJ1kVdsM8kgOAF25XaVChsljERHRcSa8sEcWjLKyKvJXBujr7W3Ag2QUPpQYq60hYMgYZ+wRwIKXTst8477HcAIg3Rb3gRePUs8/NN4Y1Xa9QS6E9D2PAQEhAhAPknGehpINmAcOtNSXW8GD0DM+AiDnYOrtJlfohVE0GvHHVyD3ozSNQ19odwIXAFUxrbnAOmAIIgiE3v36+brFeDTNlhgGj7/kMkqSJPS9AZ7IZbx0Y5qeMSpCDsxLRoFZ/fK3nyuczJYXEE8B8DgrmQziJI4Cr7OEjv7YBcDYvlJcQBlyZMGkic3t55/+p+DZRQvjc/NsFhwAfI+7d4ELABFAEYSiDTiyoKgSe3VzsyKgIC0b9Wy4uQySNIkCj6Pzkug6ZXS1wcpjiP5ok9DqZk8A1pinlY8AgHlAzSSNfKm1K4HznO1zk3MGKJM0wv1dDQC+5PzBCxACAAfG+3ESeV5vXQfBGUBVHUcEEEEUsnbXA4ShL4V4JAAAFFymceRLwY3rRHQGMMcmoRf4XDcKuJSCM3y+HCAgCMHZy9JXAngQdbrjVpnDOvDVd2Rt1yttrPumaDAAgCEGBg7tfRICkNW62xdV2yv3bdkJAED2WxNHACCjmnKzLapOufviUwB+c4YhAJi+3m/2ed0p9yjppB54+vSyHtu3ZVHUbW+sc+KBnQDwULs1xr5oqunrMi/rrh+wGH0nwEt7N31TlmXdKvvbw/TKAN/Kqqaq6qZXAyKT7wBgQnpS8GeDbXXftm2v9P8JgEEvGY9j7+kNiAdfNCg0+x4bCKeL+TTiT+/iQkjBmbsf/j4Ans4/XGQRf4oQuBDiaXl6c4B4ujhfPPQAAQBYa4noNxaJ/6ATHBEiImcsujhfzLPUPw4BEeimKouyVa8cnH5TPeNemKRx+sOfP81GoWQAAEjWqHazurq8vq/U2wIw4cfZxYfldHZxfpYEAgkBwOquzVe//vzz7S7vXzdB8TUA98LxxZ//8odFFMeBlHjoAaua/P7m889/X3ftK0fHXwOIIM2Wv//LXxeCIT3am+2r/d3t9Zcv24GJ6+EAfpotzs+Xi+jwfKzPtvndzc1qkw9NmQ6ehjzMPvzuh8X4MSA75u6ru19/+bzKB3X/SQAsmn388UMWPHb04YMu15f//HI/PFs6HCAYzRazVGiAQ7B+KLZtfr/e1sNz1sM9IROeJ/kh9qRnFkcAyKUc5AbhlG25aop8NCIOcEhZHsTD6XnLBKPWDDvAGQxgm81NIOLsAHDIVyGQmHzCZBJzC+2gPOUJAPXaQz5ePmslAYCcisl86ulW255eN1P6NUCz4xjMP9YpPNsVk0jjs4nX7XetJufA9DQA1eT+/epmrIU4+mEAAIZcYjk7yypt9JDVaLgR2r4t7r/EdpOOx9GDyRMCQBCPslndd6+cqPxa1vT15ldbnC8/ifCxlBAAZJzN67Z65UTlVyKyut3banOXszhJnn9lWTRZNPV++6YAQFa31JV5Bck4ohDpyRBENKnaarutevdTk+E9YIxhPZOVklFgz2KPe76QB6/gRVNtmqJSVa9cc/anBKfGKIBKITP72TiJkzThh42hiCxD1XS0zcu3BAAAALVBatazsyybzsE7nOWJkAfSdAp8VK5T4WQAsAV2u2w+X9aWB+EhLvC9SKi2t0w1tePOwB0AERnnHI87ACKm96ppmq6zXPCQcQbIAdKsarVtm7Z0i9FcARAZl2GSRBLJEiDavqmbsmvqcl91XTeKwkAAAHjxmQJmDW3bziVMdgZg3Iumy+VZxK22jDNTra+vd01Z7tb7qqnnWcYPhuCP0ZNEGOxzcvDJ7hcYuBef/fCnTyNplOGS6/1n2dZN1+SbWlndWS8GAACSqR9woxSibh1S5u5DwGU4Wv74p0ya3nBP6K1stkXXK9WLeJREo8MlBiLBA6mKzaYsPf7f3joAABCZCNJsfnboAaG9ervrZdBqlAysedoGIfj+y8TFqwAAMi79KE2E1YZJZu38hz6Y3RW1TbNRFMhnNVqj+67tnKLUAQCAXEjPY5ZZxpHCTMlsfbvZq3A6n6ah9wTQtVVZlnXvki0c4IgQkAnBgTOLDNAbYTzbzO+2rZdk03F0HHEi0m1dFXlRO11tGeIJkXEuGRwOasFDESZJEKUtD0ej5BinAxAZ3TdVWbklCoZ4QoZcPMsISSYERxl3zIui6DFbRdaorinzsnNKGLvPAkBgiM8CGeQQIHojhcLz/MDnBAhIYI3u6mJftuo1XTEAPEVih/cSMO6zQFlEzrl46ByyRvdNmZdu93qcAYgs2eOG9yke4vJwVvPs9ICs0apr6sZtV+QOYI1WfdcpzoAdIV4GlofeQUREssY1XesanJI1qmubuuqOloX422EociE96eoHB0THVquuKYu8/ncr3NEXI+NSuHti5yEg0n1XF9tNiMx/LDxUSc8ejsYC6NqyATag+3q3vuGqi0OOCPRgdi8Gm7Tpq7xsnKMz92lIti/Xl1hm4zT2fd8XQiCDx/ssDxah6v3m5vKueu1dMQHYvriF/HqSpqN0PBnHIePwOAAP9VO/vbq8/Hy5e4NtOanS1ndJEqeTs8X5ckqMPyM4StXrf/70y9XtmwDous2lH0bJZFH0VluAiD26RQQAoL7c3X7++z9Wef0WgQkZoxr0g6jqLZim7XsdiOMtGjLWKKXb/Ob6+vp22zif2gyPDVttLFlV3G3y5WwcHxOmSHVZ1W21v/3Hl3VeK3ptP/BMpgNS1Wq03lddTw87T52v7/dFvl1fXe8b436p8KTgtNPNTob7RlvDg6NbqjZXN+vtbrvd3BdD8vUnAJAx0ABIwyUnzmEMAFCsri+v7jbbXV6WzgZ4IsBRancXsq7NVyMAgPL2y+XqfpcXVdO97YnJk9qd6Her6SgCAGh29+tdUdVNq4acmw64Xf+teBRHYRT6EgBAN3Xddr1SA6+Ufg8AcsYZe/AD1hpLZIkG3qp917ve9a53vetd7/oXsYyZrAWZvNgAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<PIL.Image.Image image mode=L size=128x128 at 0x7F963E023390>"
+       "<PIL.Image.Image image mode=L size=128x128 at 0x7FEA922B4940>"
       ]
      },
-     "execution_count": null,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -574,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [
     {
@@ -609,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [
     {
@@ -711,14 +712,13 @@
      "text": [
       "Converted 00_test.ipynb.\n",
       "Converted 01_basics.ipynb.\n",
-      "Converted 01_foundation.ipynb.\n",
-      "Converted 02_utils-Copy1.ipynb.\n",
-      "Converted 02_utils.ipynb.\n",
-      "Converted 03_dispatch.ipynb.\n",
-      "Converted 04_transform.ipynb.\n",
-      "Converted 05_logargs.ipynb.\n",
-      "Converted 06_meta.ipynb.\n",
-      "Converted 07_script.ipynb.\n",
+      "Converted 02_foundation.ipynb.\n",
+      "Converted 03_xtras.ipynb.\n",
+      "Converted 04_dispatch.ipynb.\n",
+      "Converted 05_transform.ipynb.\n",
+      "Converted 06_logargs.ipynb.\n",
+      "Converted 07_meta.ipynb.\n",
+      "Converted 08_script.ipynb.\n",
       "Converted index.ipynb.\n"
      ]
     }
@@ -745,8 +745,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/nbs/05_transform.ipynb
+++ b/nbs/05_transform.ipynb
@@ -1217,7 +1217,9 @@
     "    def setup(self, items=None, train_setup=False):\n",
     "        tfms = self.fs[:]\n",
     "        self.fs.clear()\n",
-    "        for t in tfms: self.add(t,items, train_setup)\n",
+    "        for t in tfms: \n",
+    "            self.add(t,items, train_setup)\n",
+    "            items = t(items)\n",
     "\n",
     "    def add(self,t, items=None, train_setup=False):\n",
     "        t.setup(items, train_setup)\n",
@@ -1534,7 +1536,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Pipeline.__call__\" class=\"doc_header\"><code>Pipeline.__call__</code><a href=\"__main__.py#L26\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Pipeline.__call__\" class=\"doc_header\"><code>Pipeline.__call__</code><a href=\"__main__.py#L28\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Pipeline.__call__</code>(**`o`**)\n",
        "\n",
@@ -1560,7 +1562,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Pipeline.decode\" class=\"doc_header\"><code>Pipeline.decode</code><a href=\"__main__.py#L33\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Pipeline.decode\" class=\"doc_header\"><code>Pipeline.decode</code><a href=\"__main__.py#L35\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Pipeline.decode</code>(**`o`**, **`full`**=*`True`*)\n",
        "\n",
@@ -1617,6 +1619,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "class A(Transform):\n",
+    "    def encodes(self, x: str): return [int(n) for n in x.split(',')]\n",
+    "class B(Transform):\n",
+    "    def setups(self, x: list): self.max= max(x)\n",
+    "    def encodes(self, x: list): return [n/self.max for n in x]\n",
+    "pipe = Pipeline([A,B])\n",
+    "pipe.setup('1,2,3,4,5')\n",
+    "test_eq(pipe('1,2,3,4,5'), [0.2, 0.4, 0.6, 0.8, 1.0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#hide\n",
     "#Test is with TfmdList"
    ]
@@ -1638,10 +1656,14 @@
      "output_type": "stream",
      "text": [
       "Converted 00_test.ipynb.\n",
-      "Converted 01_foundation.ipynb.\n",
-      "Converted 02_utils.ipynb.\n",
-      "Converted 03_dispatch.ipynb.\n",
-      "Converted 04_transform.ipynb.\n",
+      "Converted 01_basics.ipynb.\n",
+      "Converted 02_foundation.ipynb.\n",
+      "Converted 03_xtras.ipynb.\n",
+      "Converted 04_dispatch.ipynb.\n",
+      "Converted 05_transform.ipynb.\n",
+      "Converted 06_logargs.ipynb.\n",
+      "Converted 07_meta.ipynb.\n",
+      "Converted 08_script.ipynb.\n",
       "Converted index.ipynb.\n"
      ]
     }
@@ -1671,5 +1693,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Fix issue that when callin setup on a Pipeline, the items where not transformed and carried along the pipeline, an example of the issue can be seen on this example:
```python
class A(Transform):
    def setups(self, x):
        print(f'A: {x}')
    def encodes(self, x): return 'a'
    
class B(Transform):
    def setups(self, x):
        print(f'B: {x}')
    def encodes(self, x): return 'b'

pipe = Pipeline([A,B])

pipe.setup(1)
>> A: 1
   B: 1
```
Transform B should receive the items after passing trough `A` first, so the print on the `B` class setup, should print the output of class `A`, hence 'a'.
The fix is really simple, just pass the tfmd items along, I noticed that this `patch` fixed the issue:
```python
@patch
def setup(self:Pipeline, items=None, train_setup=False):
    tfms = self.fs[:]
    self.fs.clear()
    for t in tfms: 
        self.add(t,items, train_setup)
        items = t(items)
```
so this is the proposed fix, along a test example.