### PR TITLE
fixed equal for tensors

### DIFF
--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -49,9 +49,7 @@ def isinstance_str(x, cls_name):
 def array_equal(a,b):
     if hasattr(a, '__array__'): a = a.__array__()
     if hasattr(b, '__array__'): b = b.__array__()
-    a_shape = getattr(a,'shape',None)
-    b_shape = getattr(b,'shape',None)
-    return a_shape == b_shape and (a==b).all()
+    return (a==b).all()
 
 def equals(a,b):
     "Compares `a` and `b` for equality; supports sublists, tensors and arrays too"

--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -49,7 +49,9 @@ def isinstance_str(x, cls_name):
 def array_equal(a,b):
     if hasattr(a, '__array__'): a = a.__array__()
     if hasattr(b, '__array__'): b = b.__array__()
-    return (a==b).all()
+    a_shape = getattr(a,'shape',None)
+    b_shape = getattr(b,'shape',None)
+    return a_shape == b_shape and (a==b).all()
 
 def equals(a,b):
     "Compares `a` and `b` for equality; supports sublists, tensors and arrays too"
@@ -58,6 +60,7 @@ def equals(a,b):
     if hasattr(a, '__array_eq__'): return a.__array_eq__(b)
     if hasattr(b, '__array_eq__'): return b.__array_eq__(a)
     cmp = (array_equal   if isinstance_str(a, 'ndarray') or isinstance_str(b, 'ndarray') else
+           array_equal   if isinstance_str(a, 'Tensor')  or isinstance_str(b, 'Tensor') else
            operator.eq   if any_is_instance((str,dict,set), a, b) else
            all_equal     if is_iter(a) or is_iter(b) else
            operator.eq)

--- a/nbs/00_test.ipynb
+++ b/nbs/00_test.ipynb
@@ -151,7 +151,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"equals\" class=\"doc_header\"><code>equals</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L56\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"equals\" class=\"doc_header\"><code>equals</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L54\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>equals</code>(**`a`**, **`b`**)\n",
        "\n",
@@ -278,7 +278,8 @@
    "source": [
     "test_eq(torch.zeros(10), torch.zeros(10, dtype=torch.float64))\n",
     "test_eq(torch.zeros(10), torch.ones(10)-1)\n",
-    "test_fail(lambda:test_eq(torch.zeros(10), torch.ones(1, 10)), contains='==')"
+    "test_fail(lambda:test_eq(torch.zeros(10), torch.ones(1, 10)), contains='==')\n",
+    "test_eq(torch.zeros(3), [0,0,0])"
    ]
   },
   {

--- a/nbs/00_test.ipynb
+++ b/nbs/00_test.ipynb
@@ -151,7 +151,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"equals\" class=\"doc_header\"><code>equals</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L54\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"equals\" class=\"doc_header\"><code>equals</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L56\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>equals</code>(**`a`**, **`b`**)\n",
        "\n",
@@ -251,7 +251,8 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import torch"
    ]
   },
   {
@@ -267,6 +268,17 @@
     "test_eq(df1.a,df2.a)\n",
     "class T(pd.Series): pass\n",
     "test_eq(df1.iloc[0], T(df2.iloc[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(torch.zeros(10), torch.zeros(10, dtype=torch.float64))\n",
+    "test_eq(torch.zeros(10), torch.ones(10)-1)\n",
+    "test_fail(lambda:test_eq(torch.zeros(10), torch.ones(1, 10)), contains='==')"
    ]
   },
   {
@@ -748,5 +760,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Equals does not work well for tensors, and fails when presented with tensor with different sizes.
Added tensor to use `array_equals` instead, and added tests.

Ido