### PR TITLE
add cast to output

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -259,7 +259,8 @@ def argnames(f, frame=False):
 # Cell
 def with_cast(f):
     "Decorator which uses any parameter annotations as preprocessing functions"
-    anno,params = annotations(f),argnames(f)
+    anno, out_anno, params = annotations(f), anno_ret(f), argnames(f)
+    c_out = ifnone(out_anno, noop)
     defaults = dict(zip(reversed(params), reversed(f.__defaults__ or {})))
     @functools.wraps(f)
     def _inner(*args, **kwargs):
@@ -270,7 +271,7 @@ def with_cast(f):
                 if v in kwargs: kwargs[v] = c(kwargs[v])
                 elif i<len(args): args[i] = c(args[i])
                 elif v in defaults: kwargs[v] = c(defaults[v])
-        return f(*args, **kwargs)
+        return c_out(f(*args, **kwargs))
     return _inner
 
 # Cell

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -1517,7 +1517,8 @@
     "#export\n",
     "def with_cast(f):\n",
     "    \"Decorator which uses any parameter annotations as preprocessing functions\"\n",
-    "    anno,params = annotations(f),argnames(f)\n",
+    "    anno, out_anno, params = annotations(f), anno_ret(f), argnames(f)\n",
+    "    c_out = ifnone(out_anno, noop)\n",
     "    defaults = dict(zip(reversed(params), reversed(f.__defaults__ or {})))\n",
     "    @functools.wraps(f)\n",
     "    def _inner(*args, **kwargs):\n",
@@ -1528,7 +1529,7 @@
     "                if v in kwargs: kwargs[v] = c(kwargs[v])\n",
     "                elif i<len(args): args[i] = c(args[i])\n",
     "                elif v in defaults: kwargs[v] = c(defaults[v])\n",
-    "        return f(*args, **kwargs)\n",
+    "        return c_out(f(*args, **kwargs))\n",
     "    return _inner"
    ]
   },
@@ -1539,10 +1540,17 @@
    "outputs": [],
    "source": [
     "@with_cast\n",
-    "def _f(a, b:Path, c:str='', d=0)->bool: return (a,b,c,d)\n",
+    "def _f(a, b:Path, c:str='', d=0): return (a,b,c,d)\n",
     "\n",
     "test_eq(_f(1, '.', 3), (1,Path('.'),'3',0))\n",
-    "test_eq(_f(1, '.'), (1,Path('.'),'',0))"
+    "test_eq(_f(1, '.'), (1,Path('.'),'',0))\n",
+    "\n",
+    "@with_cast\n",
+    "def _g(a:int=0)->str: return a\n",
+    "\n",
+    "test_eq(_g(4.0), '4')\n",
+    "test_eq(_g(4.4), '4')\n",
+    "test_eq(_g(2), '2')"
    ]
   },
   {
@@ -4285,7 +4293,7 @@
     {
      "data": {
       "text/plain": [
-       "64"
+       "12"
       ]
      },
      "execution_count": null,

--- a/nbs/04_dispatch.ipynb
+++ b/nbs/04_dispatch.ipynb
@@ -1446,5 +1446,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In `with_cast`:
- Add cast to output if annotation is present

Question to @jeremy : With `TensorImage` and `ArrayImage` one has to call `cast` instead of directly calling the class name (as the `__init__` is not implemented), should not we use cast in `with_cast` instead of calling the constructor directly?