### PR TITLE
Fixes #256

### DIFF
--- a/fastcore/parallel.py
+++ b/fastcore/parallel.py
@@ -97,11 +97,10 @@ except: progress_bar = None
 def parallel(f, items, *args, n_workers=defaults.cpus, total=None, progress=None, pause=0,
              threadpool=False, timeout=None, chunksize=1, **kwargs):
     "Applies `func` in parallel to `items`, using `n_workers`"
-    if progress is None: progress = progress_bar is not None
     pool = ThreadPoolExecutor if threadpool else ProcessPoolExecutor
     with pool(n_workers, pause=pause) as ex:
         r = ex.map(f,items, *args, timeout=timeout, chunksize=chunksize, **kwargs)
-        if progress:
+        if progress and progress_bar:
             if total is None: total = len(items)
             r = progress_bar(r, total=total, leave=False)
         return L(r)

--- a/nbs/03a_parallel.ipynb
+++ b/nbs/03a_parallel.ipynb
@@ -305,11 +305,10 @@
     "def parallel(f, items, *args, n_workers=defaults.cpus, total=None, progress=None, pause=0,\n",
     "             threadpool=False, timeout=None, chunksize=1, **kwargs):\n",
     "    \"Applies `func` in parallel to `items`, using `n_workers`\"\n",
-    "    if progress is None: progress = progress_bar is not None\n",
     "    pool = ThreadPoolExecutor if threadpool else ProcessPoolExecutor\n",
     "    with pool(n_workers, pause=pause) as ex:\n",
     "        r = ex.map(f,items, *args, timeout=timeout, chunksize=chunksize, **kwargs)\n",
-    "        if progress:\n",
+    "        if progress and progress_bar:\n",
     "            if total is None: total = len(items)\n",
     "            r = progress_bar(r, total=total, leave=False)\n",
     "        return L(r)"


### PR DESCRIPTION
I believe the desired behavior if a user doesn't have fast_progress installed is to continue with no progress bar rather than to throw an exception... though a warning would also be reasonable.

Here's a patch that continues without the progress bar in that case.