### PR TITLE
Some small ergonomic fixes for running with docker-compose

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,6 +2,7 @@
     "name": "fastcore-codespaces",
     "dockerComposeFile": "docker-compose.yml",
     "settings": {"terminal.integrated.shell.linux": "/bin/bash"},
+    "workspaceFolder": "/data/",
     "service": "watcher",
     "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
     "forwardPorts": [4000, 8080],
@@ -9,5 +10,5 @@
     "extensions": ["ms-python.python",
                    "ms-azuretools.vscode-docker"],
     "runServices": ["notebook", "jekyll", "watcher"],
-    "postStartCommand": "pip install -e ."
+    "postStartCommand": "cd /data && pip install -e \".[dev]\""
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   notebook:
     <<: *fastai
-    command: bash -c "pip install -e . && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
+    command: bash -c "pip install -e \".[dev]\" && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
Just a few things I found when first booting up fastcore in VS Code with the remote containers extension.

- Sets the workspace folder to /data instead of / inside the container.
- Install the dev dependencies (matplotlib) when booting the notebook container.