### PR TITLE
neptune-cli -> neptune-client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         pip install -Uqq nbdev
         cd fastai && pip install -Ue .[dev]
         cd ../fastcore && pip install -Ue .[dev]
-        pip install "sentencepiece<0.1.90" wandb tensorboard albumentations pydicom opencv-python scikit-image pyarrow kornia catalyst captum neptune-cli
+        pip install "sentencepiece<0.1.90" wandb tensorboard albumentations pydicom opencv-python scikit-image pyarrow kornia catalyst captum neptune-client
 
     - name: check for cache hit
       uses: actions/cache@v2


### PR DESCRIPTION
Not sure if neptune-cli is used anywhere, but I believe that the neptune-cli client was renamed to neptune-client.

https://github.com/neptune-ai/neptune-client

This should resolve the build errors I'm seeing:

```
ERROR: Requested neptune-cli from https://files.pythonhosted.org/packages/ba/ae/0cdcb9d20bf3b2324d21cfd11dc05246972e9759e7609739c6ce0ef01639/neptune-cli-2.8.23-1.tar.gz#sha256=343bd3d79da2c2fd10b9cd8ffb52570f8eb91573dbf290742eefb1aa643fe2eb has different version in metadata: '2.8.23'
Error: Process completed with exit code 1.
```