### PR TITLE
Fix saving str as bytes in urlsave

### DIFF
--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -139,7 +139,7 @@ def urlclean(url):
 # Cell
 def urlsave(url, dest=None):
     "Retrieve `url` and save based on its name"
-    res = urlread(urlwrap(url))
+    res = urlread(urlwrap(url), decode=False)
     if dest is None: dest = Path(url).name
     name = urlclean(dest)
     Path(name).write_bytes(res)

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -369,7 +369,7 @@
     "#export\n",
     "def urlsave(url, dest=None):\n",
     "    \"Retrieve `url` and save based on its name\"\n",
-    "    res = urlread(urlwrap(url))\n",
+    "    res = urlread(urlwrap(url), decode=False)\n",
     "    if dest is None: dest = Path(url).name\n",
     "    name = urlclean(dest)\n",
     "    Path(name).write_bytes(res)\n",


### PR DESCRIPTION
The `urlsave` function attempts to write bytes which are loaded and decoded to string in `urlread`. This switches off the decoding to have bytes object to write. This issue shows up in the `nbdev_new` command.

This is a remake of https://github.com/fastai/fastcore/pull/275 done after fixing some unrelated issues leading to merge conflicts.