### PR TITLE
Update 03_xtras: typo becuase => because

### DIFF
--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -1114,7 +1114,7 @@
    "outputs": [],
    "source": [
     "if sys.platform == 'win32':\n",
-    "    # why I ingore as_types, becuase every time nbdev_clean_nbs will update \\n to \\nn\n",
+    "    # why I ingore as_types, because every time nbdev_clean_nbs will update \\n to \\nn\n",
     "    test_eq(run('cmd /c echo hi'), 'hi')\n",
     "else:\n",
     "    test_eq(run('echo hi', as_bytes=True), b'hi\\n')"

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -1114,7 +1114,7 @@
    "outputs": [],
    "source": [
     "if sys.platform == 'win32':\n",
-    "    # why I ingore as_types, because every time nbdev_clean_nbs will update \\n to \\nn\n",
+    "    # why I ignore as_types, because every time nbdev_clean_nbs will update \\n to \\nn\n",
     "    test_eq(run('cmd /c echo hi'), 'hi')\n",
     "else:\n",
     "    test_eq(run('echo hi', as_bytes=True), b'hi\\n')"


### PR DESCRIPTION
Hello there,
I'm enjoying reading https://fastcore.fast.ai/ documentation, and I found this one-letter typo in https://fastcore.fast.ai/xtras.html#run
Thanks for your amazing work, kind regards from France. -- @Naereen