### PR TITLE
Clarify definition of le in fasttuple

### DIFF
--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -3585,7 +3585,7 @@
     "#### Other Elementwise Operations\n",
     "\n",
     "Additionally, the following elementwise operations are available:\n",
-    "- `le`: less than\n",
+    "- `le`: less than or equal\n",
     "- `eq`: equal\n",
     "- `gt`: greater than\n",
     "- `min`: minimum of"


### PR DESCRIPTION
Correct definition of `le` in fasttuple docs from "less than" to "less than or equal"