### PR TITLE
make patch more compatible with classmethods

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -782,6 +782,7 @@ def patch(f=None, *, as_prop=False, cls_method=False):
     "Decorator: add `f` to the first parameter's class (based on f's type annotations)"
     if f is None: return partial(patch, as_prop=as_prop, cls_method=cls_method)
     cls = next(iter(f.__annotations__.values()))
+    if cls_method: cls = f.__annotations__.pop('cls')
     return patch_to(cls, as_prop=as_prop, cls_method=cls_method)(f)
 
 # Cell

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +187,7 @@
        "(True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -254,7 +254,7 @@
        "        [6, 7, 8]])]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -275,7 +275,7 @@
        "[array([1, 2])]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +404,7 @@
        " (None, False)]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -442,7 +442,7 @@
        "False"
       ]
      },
-     "execution_count": null,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +474,7 @@
        "False"
       ]
      },
-     "execution_count": null,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -543,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -619,7 +619,7 @@
        "{}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -820,7 +820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -856,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -944,7 +944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1013,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1023,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1057,7 +1057,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1075,7 +1075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -1084,7 +1084,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1095,7 +1095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1119,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1131,7 +1131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,7 +1143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1157,7 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1182,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1214,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1257,7 +1257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1284,7 +1284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -1310,7 +1310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1329,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1348,7 +1348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -1363,7 +1363,7 @@
        " method_descriptor]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1381,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1435,7 +1435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1446,7 +1446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1478,7 +1478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1497,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1509,7 +1509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1522,7 +1522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1531,7 +1531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1556,7 +1556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,7 +1591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1623,7 +1623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1640,7 +1640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1657,7 +1657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1674,7 +1674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1690,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1703,7 +1703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1726,7 +1726,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1768,7 +1768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1781,7 +1781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1796,7 +1796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1812,7 +1812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1834,7 +1834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1849,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1874,7 +1874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1895,7 +1895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1915,7 +1915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1930,7 +1930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1942,7 +1942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1955,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1967,7 +1967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1982,7 +1982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1994,7 +1994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2006,7 +2006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2015,7 +2015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2038,7 +2038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2050,7 +2050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2059,7 +2059,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2071,7 +2071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,7 +2093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2105,7 +2105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
@@ -2114,7 +2114,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2126,7 +2126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2138,7 +2138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2148,7 +2148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2161,7 +2161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2174,7 +2174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2187,7 +2187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2202,7 +2202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2219,7 +2219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2235,7 +2235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [
     {
@@ -2309,7 +2309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2333,7 +2333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2352,7 +2352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2368,7 +2368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2395,7 +2395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2420,7 +2420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2448,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2469,7 +2469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2492,7 +2492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2518,7 +2518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2546,7 +2546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2569,7 +2569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2579,7 +2579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2614,7 +2614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2636,7 +2636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2649,7 +2649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2672,7 +2672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [
     {
@@ -2702,7 +2702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2714,7 +2714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [
     {
@@ -2723,7 +2723,7 @@
        "[0, 1, 2, 3, 4]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2734,7 +2734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2746,7 +2746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2756,7 +2756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2768,7 +2768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 154,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2780,7 +2780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2792,7 +2792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2803,7 +2803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2815,7 +2815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2829,7 +2829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2841,7 +2841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2852,7 +2852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2864,7 +2864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2873,7 +2873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2891,7 +2891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2907,16 +2907,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{1: [0], 3: [0, 2], 7: [0], 5: [3, 7], 8: [4], 4: [5]}"
+       "{1: [0], 3: [0, 2], 4: [5], 5: [3, 7], 7: [0], 8: [4]}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 165,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2928,7 +2928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2941,7 +2941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2951,7 +2951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2963,7 +2963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 169,
    "metadata": {},
    "outputs": [
     {
@@ -2972,7 +2972,7 @@
        "{65: 'A', 66: 'B', 67: 'C', 68: 'D', 69: 'E', 70: 'F', 71: 'G', 72: 'H'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 169,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2984,7 +2984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 170,
    "metadata": {},
    "outputs": [
     {
@@ -2993,7 +2993,7 @@
        "{65: 'A', 66: 'B', 70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 170,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3004,7 +3004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3016,7 +3016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 172,
    "metadata": {},
    "outputs": [
     {
@@ -3025,7 +3025,7 @@
        "{65: 'A', 66: 'B'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 172,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3036,7 +3036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3048,7 +3048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 174,
    "metadata": {},
    "outputs": [
     {
@@ -3057,7 +3057,7 @@
        "{70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3068,7 +3068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3081,7 +3081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3093,7 +3093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3105,7 +3105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3114,7 +3114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3129,7 +3129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3142,7 +3142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3154,7 +3154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3168,7 +3168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3185,7 +3185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3198,7 +3198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3208,7 +3208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3220,7 +3220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3229,7 +3229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3243,7 +3243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3254,7 +3254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3269,7 +3269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3280,7 +3280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3295,7 +3295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3308,7 +3308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3320,7 +3320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 195,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3329,7 +3329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3344,7 +3344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3371,7 +3371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3392,7 +3392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3436,7 +3436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [
     {
@@ -3490,7 +3490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3508,7 +3508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 202,
    "metadata": {},
    "outputs": [
     {
@@ -3534,7 +3534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 203,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3545,7 +3545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 204,
    "metadata": {},
    "outputs": [
     {
@@ -3571,7 +3571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3593,7 +3593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3612,7 +3612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3624,7 +3624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 208,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3650,7 +3650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 209,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3666,7 +3666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 210,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3688,7 +3688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 211,
    "metadata": {},
    "outputs": [
     {
@@ -3723,7 +3723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 212,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3743,7 +3743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 213,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3764,7 +3764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 214,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3780,7 +3780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3796,7 +3796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 216,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3805,7 +3805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 217,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3817,7 +3817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 218,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3827,7 +3827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 219,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3844,7 +3844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 220,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3860,7 +3860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3876,7 +3876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 222,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3892,7 +3892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 223,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3902,7 +3902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 224,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3921,7 +3921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3937,7 +3937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 226,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3951,7 +3951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3962,7 +3962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3978,7 +3978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3998,7 +3998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4014,7 +4014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4025,7 +4025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 232,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4037,7 +4037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 233,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4047,7 +4047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4057,7 +4057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 235,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4069,7 +4069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 236,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4094,7 +4094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 237,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4133,7 +4133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 238,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4148,7 +4148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 239,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4167,7 +4167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 240,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4208,7 +4208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 241,
    "metadata": {},
    "outputs": [
     {
@@ -4217,7 +4217,7 @@
        "[5, 2]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 241,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4238,7 +4238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 242,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4261,7 +4261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 243,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4285,7 +4285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 244,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4295,7 +4295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 245,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4306,7 +4306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 246,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4339,7 +4339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 247,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4361,7 +4361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4384,7 +4384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 249,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4405,7 +4405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4425,7 +4425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 251,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4443,7 +4443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 252,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4452,6 +4452,7 @@
     "    \"Decorator: add `f` to the first parameter's class (based on f's type annotations)\"\n",
     "    if f is None: return partial(patch, as_prop=as_prop, cls_method=cls_method)\n",
     "    cls = next(iter(f.__annotations__.values()))\n",
+    "    if cls_method: cls = f.__annotations__.pop('cls')\n",
     "    return patch_to(cls, as_prop=as_prop, cls_method=cls_method)(f)"
    ]
   },
@@ -4464,7 +4465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 253,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4487,7 +4488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 254,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4514,7 +4515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4527,7 +4528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 256,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4541,7 +4542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4562,7 +4563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4577,7 +4578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 259,
    "metadata": {},
    "outputs": [
     {
@@ -4603,7 +4604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 260,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4615,7 +4616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 261,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4627,7 +4628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 262,
    "metadata": {},
    "outputs": [
     {
@@ -4637,7 +4638,7 @@
        "\n",
        "> <code>Enum</code> = []\n",
        "\n",
-       "An `ImportEnum` that behaves like a `str`"
+       "An [`ImportEnum`](/basics.html#ImportEnum) that behaves like a `str`"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -4653,7 +4654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 263,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4665,7 +4666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 264,
    "metadata": {},
    "outputs": [
     {
@@ -4686,7 +4687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 265,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4713,7 +4714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 266,
    "metadata": {},
    "outputs": [
     {
@@ -4739,7 +4740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 267,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4766,7 +4767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 268,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4789,7 +4790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 269,
    "metadata": {},
    "outputs": [
     {
@@ -4813,7 +4814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 270,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4825,7 +4826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 271,
    "metadata": {},
    "outputs": [
     {
@@ -4858,16 +4859,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 272,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
       "text/plain": [
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 272,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4886,11 +4890,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 273,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
       "text/plain": [
        "a string\n",
        "with\n",
@@ -4898,7 +4905,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": null,
+     "execution_count": 273,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4909,7 +4916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 274,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4924,7 +4931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 275,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4935,7 +4942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 276,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4950,16 +4957,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 277,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "12"
+       "4"
       ]
      },
-     "execution_count": null,
+     "execution_count": 277,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4970,7 +4977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 278,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4983,7 +4990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 279,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4996,7 +5003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 280,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5016,7 +5023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 281,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5026,7 +5033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5059,7 +5066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 283,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5079,7 +5086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5091,7 +5098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 285,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5119,7 +5126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 286,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5142,13 +5149,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 287,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ipython_shell\" class=\"doc_header\"><code>ipython_shell</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L67\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"ipython_shell\" class=\"doc_header\"><code>ipython_shell</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L70\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>ipython_shell</code>()\n",
        "\n",
@@ -5168,13 +5175,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 288,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"in_ipython\" class=\"doc_header\"><code>in_ipython</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L72\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"in_ipython\" class=\"doc_header\"><code>in_ipython</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L75\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>in_ipython</code>()\n",
        "\n",
@@ -5194,13 +5201,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 289,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"in_colab\" class=\"doc_header\"><code>in_colab</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L76\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"in_colab\" class=\"doc_header\"><code>in_colab</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L79\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>in_colab</code>()\n",
        "\n",
@@ -5220,13 +5227,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 290,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"in_jupyter\" class=\"doc_header\"><code>in_jupyter</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L80\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"in_jupyter\" class=\"doc_header\"><code>in_jupyter</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L83\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>in_jupyter</code>()\n",
        "\n",
@@ -5246,13 +5253,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 291,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"in_notebook\" class=\"doc_header\"><code>in_notebook</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L85\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"in_notebook\" class=\"doc_header\"><code>in_notebook</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L88\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>in_notebook</code>()\n",
        "\n",
@@ -5279,16 +5286,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 292,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(True, True, False, True)"
+       "(True, False, True, True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 292,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5306,7 +5313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 293,
    "metadata": {},
    "outputs": [
     {
@@ -5335,7 +5342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -5349,6 +5356,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +187,7 @@
        "(True, False)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -254,7 +254,7 @@
        "        [6, 7, 8]])]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -275,7 +275,7 @@
        "[array([1, 2])]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +404,7 @@
        " (None, False)]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -442,7 +442,7 @@
        "False"
       ]
      },
-     "execution_count": 26,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +474,7 @@
        "False"
       ]
      },
-     "execution_count": 28,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -543,7 +543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -619,7 +619,7 @@
        "{}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -706,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -820,7 +820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -856,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,7 +875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -944,7 +944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1013,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1023,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1057,7 +1057,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": 58,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1075,7 +1075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1084,7 +1084,7 @@
        "(True, False, True, False)"
       ]
      },
-     "execution_count": 59,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1095,7 +1095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1119,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1131,7 +1131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,7 +1143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1157,7 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1182,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1214,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1257,7 +1257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1284,7 +1284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1310,7 +1310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1329,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1348,7 +1348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1363,7 +1363,7 @@
        " method_descriptor]"
       ]
      },
-     "execution_count": 75,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1381,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,7 +1411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1435,7 +1435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1446,7 +1446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1478,7 +1478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1497,7 +1497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1509,7 +1509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1522,7 +1522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1531,7 +1531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1556,7 +1556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,7 +1591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1623,7 +1623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1640,7 +1640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1657,7 +1657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1674,7 +1674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1690,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1703,7 +1703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1726,7 +1726,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1768,7 +1768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1781,7 +1781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1796,7 +1796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1812,7 +1812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1834,7 +1834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1849,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1874,7 +1874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1895,7 +1895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1915,7 +1915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1930,7 +1930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1942,7 +1942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1955,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1967,7 +1967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1982,7 +1982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1994,7 +1994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2006,7 +2006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2015,7 +2015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2028,7 +2028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2038,7 +2038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2050,7 +2050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2059,7 +2059,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2071,7 +2071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,7 +2093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2105,7 +2105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2114,7 +2114,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": 121,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2126,7 +2126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2138,7 +2138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2148,7 +2148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2161,7 +2161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2174,7 +2174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2187,7 +2187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2202,7 +2202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2219,7 +2219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2235,7 +2235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2309,7 +2309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2333,7 +2333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2352,7 +2352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2368,7 +2368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2395,7 +2395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2420,7 +2420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2448,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2469,7 +2469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2492,7 +2492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2518,7 +2518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2546,7 +2546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2569,7 +2569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2579,7 +2579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2614,7 +2614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2636,7 +2636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2649,7 +2649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2672,7 +2672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2702,7 +2702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2714,7 +2714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2723,7 +2723,7 @@
        "[0, 1, 2, 3, 4]"
       ]
      },
-     "execution_count": 150,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2734,7 +2734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2746,7 +2746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2756,7 +2756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2768,7 +2768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2780,7 +2780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2792,7 +2792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2803,7 +2803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2815,7 +2815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2829,7 +2829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2841,7 +2841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2852,7 +2852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2864,7 +2864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2873,7 +2873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2891,7 +2891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2907,7 +2907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2916,7 +2916,7 @@
        "{1: [0], 3: [0, 2], 4: [5], 5: [3, 7], 7: [0], 8: [4]}"
       ]
      },
-     "execution_count": 165,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2928,7 +2928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2941,7 +2941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2951,7 +2951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2963,7 +2963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2972,7 +2972,7 @@
        "{65: 'A', 66: 'B', 67: 'C', 68: 'D', 69: 'E', 70: 'F', 71: 'G', 72: 'H'}"
       ]
      },
-     "execution_count": 169,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2984,7 +2984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2993,7 +2993,7 @@
        "{65: 'A', 66: 'B', 70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": 170,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3004,7 +3004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3016,7 +3016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3025,7 +3025,7 @@
        "{65: 'A', 66: 'B'}"
       ]
      },
-     "execution_count": 172,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3036,7 +3036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3048,7 +3048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3057,7 +3057,7 @@
        "{70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": 174,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3068,7 +3068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3081,7 +3081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3093,7 +3093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3105,7 +3105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3114,7 +3114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3129,7 +3129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3142,7 +3142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3154,7 +3154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3168,7 +3168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3185,7 +3185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3198,7 +3198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3208,7 +3208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3220,7 +3220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3229,7 +3229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3243,7 +3243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3254,7 +3254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3269,7 +3269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3280,7 +3280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3295,7 +3295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3308,7 +3308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3320,7 +3320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3329,7 +3329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3344,7 +3344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3371,7 +3371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3392,7 +3392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3436,7 +3436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3490,7 +3490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3508,7 +3508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3534,7 +3534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3545,7 +3545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3571,7 +3571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3593,7 +3593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3612,7 +3612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3624,7 +3624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3650,7 +3650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3666,7 +3666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 210,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3688,7 +3688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3723,7 +3723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 212,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3743,7 +3743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3764,7 +3764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3780,7 +3780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3796,7 +3796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 216,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3805,7 +3805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3817,7 +3817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3827,7 +3827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 219,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3844,7 +3844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3860,7 +3860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3876,7 +3876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3892,7 +3892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3902,7 +3902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3921,7 +3921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3937,7 +3937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3951,7 +3951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3962,7 +3962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3978,7 +3978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3998,7 +3998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4014,7 +4014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4025,7 +4025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4037,7 +4037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4047,7 +4047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4057,7 +4057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4069,7 +4069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4094,7 +4094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4133,7 +4133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4148,7 +4148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4167,7 +4167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4208,7 +4208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4217,7 +4217,7 @@
        "[5, 2]"
       ]
      },
-     "execution_count": 241,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4238,7 +4238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4261,7 +4261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4285,7 +4285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4295,7 +4295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4306,7 +4306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4339,7 +4339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4361,7 +4361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4384,7 +4384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4405,7 +4405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4425,7 +4425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 251,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4443,7 +4443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 252,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4465,7 +4465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4488,7 +4488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4515,7 +4515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4528,7 +4528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4542,7 +4542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4563,7 +4563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 258,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4578,7 +4578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4604,7 +4604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 260,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4616,7 +4616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 261,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4628,7 +4628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 262,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4654,7 +4654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 263,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4666,7 +4666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4687,7 +4687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 265,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4714,7 +4714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 266,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4740,7 +4740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 267,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4767,7 +4767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 268,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4790,7 +4790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 269,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4814,7 +4814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 270,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4826,7 +4826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 271,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4859,19 +4859,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 272,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "type": "string"
-      },
       "text/plain": [
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": 272,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4890,14 +4887,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 273,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "type": "string"
-      },
       "text/plain": [
        "a string\n",
        "with\n",
@@ -4905,7 +4899,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": 273,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4916,7 +4910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 274,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4931,7 +4925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 275,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4942,7 +4936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 276,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4957,7 +4951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 277,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4966,7 +4960,7 @@
        "4"
       ]
      },
-     "execution_count": 277,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4977,7 +4971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 278,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4990,7 +4984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 279,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5003,7 +4997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 280,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5023,7 +5017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 281,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5033,7 +5027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 282,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5066,7 +5060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 283,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5086,7 +5080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 284,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5098,7 +5092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 285,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5126,7 +5120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 286,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5149,7 +5143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 287,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5175,7 +5169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 288,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5201,7 +5195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 289,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5227,7 +5221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 290,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5253,7 +5247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 291,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5286,7 +5280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 292,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5295,7 +5289,7 @@
        "(True, False, True, True)"
       ]
      },
-     "execution_count": 292,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5313,7 +5307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 293,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5342,7 +5336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -5356,18 +5350,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pr helps fix an issue that was reported on the forums. `patch` when used with classmethods propagates the type_hints of the `cls` arg into the `patch_to` function. This causes `Transform`'s `TypeDispatch` to receive the wrong type_hints