### PR TITLE
Make join_path_file() check if the same extension in file is passed as ext and remove it

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -126,7 +126,10 @@ def join_path_file(file, path, ext=''):
     "Return `path/file` if file is a string or a `Path`, file otherwise"
     if not isinstance(file, (str, Path)): return file
     path.mkdir(parents=True, exist_ok=True)
-    return path/f'{file}{ext}'
+    split = os.path.splitext(file)
+    fn,ex = split[0],split[1]
+    fn = fn+ex if ext != ex else fn
+    return path/f'{fn}{ext}'
 
 # Cell
 def loads(s, cls=None, object_hook=None, parse_float=None,


### PR DESCRIPTION
Now join_path_file() checks if the same extension passed as ext is already in the file string and removes it. (Made this change at the n-th "no such file or directory <blah.pth.pth>" doing a learn.load() -- with n very big.)