### PR TITLE
Use default TemporaryDirectory in "untar_dir"

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -175,7 +175,7 @@ def _unpack(fname, out):
 # Cell
 def untar_dir(fname, dest, rename=False, overwrite=False):
     "untar `file` into `dest`, creating a directory if the root contains more than one item"
-    with tempfile.TemporaryDirectory(dir='.') as d:
+    with tempfile.TemporaryDirectory() as d:
         out = Path(d)/remove_suffix(Path(fname).stem, '.tar')
         out.mkdir()
         if rename: dest = dest/out.name

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -1023,7 +1023,7 @@
     "#export\n",
     "def untar_dir(fname, dest, rename=False, overwrite=False):\n",
     "    \"untar `file` into `dest`, creating a directory if the root contains more than one item\"\n",
-    "    with tempfile.TemporaryDirectory(dir='.') as d:\n",
+    "    with tempfile.TemporaryDirectory() as d:\n",
     "        out = Path(d)/remove_suffix(Path(fname).stem, '.tar')\n",
     "        out.mkdir()\n",
     "        if rename: dest = dest/out.name\n",


### PR DESCRIPTION
Prevents issues when current working directory is unwritable, or inappropriate for large amounts of data.

Fixes https://github.com/fastai/fastcore/issues/353.

I have _not_ written a test - figuring this is a trivial change, and doesn't alter functionality - but can (attempt to) do so if requested.