### PR TITLE
Add ismin_version & notmax_version

### DIFF
--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -5,6 +5,7 @@ from warnings import warn
 from typing import Iterable,Generator,Sequence,Iterator,List,Set,Dict,Union,Optional
 from functools import partial,reduce
 from pathlib import Path
+from packaging.version import parse
 
 try:
     from types import WrapperDescriptorType,MethodWrapperType,MethodDescriptorType
@@ -99,3 +100,10 @@ def remove_suffix(text, suffix):
     "Temporary until py39 is a prereq"
     return text[:-len(suffix)] if text.endswith(suffix) else text
 
+def ismin_version(min_version, package_version):
+    "Check if `package_version` >= `min_version` using packaging.version"
+    return parse(package_version) >= parse(min_version)
+
+def notmax_version(max_version, package_version):
+    "Check if `package_version` < `max_version` using packaging.version"
+    return  parse(package_version) < parse(max_version)

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -5453,6 +5453,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Package version functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"ismin_version\" class=\"doc_header\"><code>ismin_version</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L103\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>ismin_version</code>(**`min_version`**, **`package_version`**)\n",
+       "\n",
+       "Check if `package_version` >= `min_version` using packaging.version"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(ismin_version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"notmax_version\" class=\"doc_header\"><code>notmax_version</code><a href=\"https://github.com/fastai/fastcore/tree/master/fastcore/imports.py#L107\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>notmax_version</code>(**`max_version`**, **`package_version`**)\n",
+       "\n",
+       "Check if `package_version` < `max_version` using packaging.version"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(notmax_version)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Export -"
    ]
   },
@@ -5500,8 +5559,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
+   "display_name": "Python 3.9.5 64-bit ('base': conda)",
    "name": "python3"
   }
  },


### PR DESCRIPTION
Adds version checks with packaging.version. For resolving issues with current fastai torch version checking brought up in fastai/fastai#3511.

