### PR TITLE
refactor `_TypeDict`

### DIFF
--- a/nbs/04_dispatch.ipynb
+++ b/nbs/04_dispatch.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "#export\n",
     "def sorted_topologically(iterable, *, cmp=operator.lt, reverse=False):\n",
-    "    \"Return a new list containing all items from the iterable sorted topologically\"\n",
+    "    \"Return a new list containing all items from `iterable` sorted topologically.\"\n",
     "    l,res = L(list(iterable)),[]\n",
     "    for _ in range(len(l)):\n",
     "        t = l.reduce(lambda x,y: y if cmp(y,x) else x)\n",
@@ -152,7 +152,7 @@
    "source": [
     "#export\n",
     "def _p2_anno(f):\n",
-    "    \"Get the 1st 2 annotations of `f`, defaulting to `object`\"\n",
+    "    \"Get 1st 2 annotations of `f`, defaulting to `object`\"\n",
     "    hints = type_hints(f)\n",
     "    ann = [o for n,o in hints.items() if n!='return']\n",
     "    if callable(f): _chk_defaults(f, ann)\n",
@@ -251,31 +251,28 @@
    "source": [
     "#export\n",
     "class _TypeDict:\n",
+    "    \"Dict-like keyed by types and matched by `lenient_issubclass`\"\n",
     "    def __init__(self): self.d,self.cache = {},{}\n",
     "\n",
-    "    def _reset(self):\n",
-    "        self.d = {k:self.d[k] for k in sorted_topologically(self.d, cmp=lenient_issubclass)}\n",
+    "    def __setitem__(self, t, v):\n",
+    "        \"Map type `t` (tuple interpreted as union) to `v`\"\n",
+    "        for t_ in L(t): self.d[t_] = v\n",
+    "        self.d = {k:self.d[k] for k in sorted_topologically(self.d,cmp=lenient_issubclass)}\n",
     "        self.cache = {}\n",
     "\n",
-    "    def add(self, t, f):\n",
-    "        \"Add type `t` and function `f`\"\n",
-    "        if not isinstance(t,tuple): t=tuple(L(t))\n",
-    "        for t_ in t: self.d[t_] = f\n",
-    "        self._reset()\n",
+    "    def setdefault(self, t, default):\n",
+    "        v = self.d.get(t)\n",
+    "        if v is None: v = self[t] = default\n",
+    "        return v\n",
     "\n",
-    "    def all_matches(self, k):\n",
-    "        \"Find first matching type that is a super-class of `k`\"\n",
-    "        if k not in self.cache:\n",
-    "            types = [f for f in self.d if lenient_issubclass(k,f)]\n",
-    "            self.cache[k] = [self.d[o] for o in types]\n",
-    "        return self.cache[k]\n",
+    "    def all_matches(self, t):\n",
+    "        \"Find all values matching types that are a super-class of `t`\"\n",
+    "        vs = self.cache.get(t)\n",
+    "        if vs is None: vs = self.cache[t] = [v for k, v in self.d.items() if lenient_issubclass(t,k)]\n",
+    "        return vs\n",
     "\n",
-    "    def __getitem__(self, k):\n",
-    "        \"Find first matching type that is a super-class of `k`\"\n",
-    "        res = self.all_matches(k)\n",
-    "        return res[0] if len(res) else None\n",
-    "\n",
-    "    def __repr__(self): return self.d.__repr__()\n",
+    "    def __getitem__(self, t): return first(self.all_matches(t))\n",
+    "    def __repr__(self): return repr(self.d)\n",
     "    def first(self): return first(self.d.values())"
    ]
   },
@@ -298,11 +295,7 @@
     "        \"Add type `t` and function `f`\"\n",
     "        if isinstance(f, staticmethod): a0,a1 = _p2_anno(f.__func__)\n",
     "        else: a0,a1 = _p2_anno(f)\n",
-    "        t = self.funcs.d.get(a0)\n",
-    "        if t is None:\n",
-    "            t = _TypeDict()\n",
-    "            self.funcs.add(a0, t)\n",
-    "        t.add(a1, f)\n",
+    "        self.funcs.setdefault(a0,_TypeDict())[a1] = f\n",
     "\n",
     "    def first(self):\n",
     "        \"Get first function in ordered dict of type:func.\"\n",
@@ -795,7 +788,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"TypeDispatch.__call__\" class=\"doc_header\"><code>TypeDispatch.__call__</code><a href=\"__main__.py#L35\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"TypeDispatch.__call__\" class=\"doc_header\"><code>TypeDispatch.__call__</code><a href=\"__main__.py#L31\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>TypeDispatch.__call__</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -883,7 +876,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"TypeDispatch.returns\" class=\"doc_header\"><code>TypeDispatch.returns</code><a href=\"__main__.py#L24\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"TypeDispatch.returns\" class=\"doc_header\"><code>TypeDispatch.returns</code><a href=\"__main__.py#L20\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>TypeDispatch.returns</code>(**`x`**)\n",
        "\n",
@@ -1409,13 +1402,6 @@
     "from nbdev.export import notebook2script\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
#### Context

I'm in the process of deep-diving fastai (specifically the tabular sections) and fastcore while on a sabbatical. I'm a big fan so far - it's so user-friendly, and the programming style is reminding me why I got into programming to begin with 😄! While interacting with the notebooks I'm finding tiny opportunities to clean up the implementation and docs.

I hope this is seen as a positive contribution rather than bike shedding. If it doesn't look valuable, please let me know. I'd be more than happy to change my approach and try something else 😃

For interest sake, this PR is a small part of a broader clean up of the dispatch notebook available in my forked master branch (view the full diff [here](https://github.com/fastai/fastcore/compare/master...seeM:master) and the updated notebook [here](https://github.com/seeM/fastcore/blob/master/nbs/04_dispatch.ipynb)). That branch includes more work along these lines, as well as a restructuring of the docs that I found helpful in developing my understanding of the library. I'd be very happy to continue carving out PRs like this from that branch

#### Description of changes

_(commit messages copied as-is)_

Make it more dict-like with fewer lines where appropriate:

- Rename `add` to `__setitem__`
- Add `setdefault` which cleans up `TypeDispatch.add`

Also renamed args for consistency: vars referring to keys are named `t`
since they will always be types, and vars referring to values are named
`v` (or `vs`) because they may be functions or nested `_TypeDict`s.