### PR TITLE
fix parallel on macos

### DIFF
--- a/fastcore/parallel.py
+++ b/fastcore/parallel.py
@@ -10,14 +10,12 @@ from .basics import *
 from .xtras import *
 from functools import wraps
 
-# from contextlib import contextmanager,ExitStack
 from multiprocessing import Process, Queue
 import concurrent.futures,time
 from multiprocessing import Manager, set_start_method
 from threading import Thread
-
 try:
-    if sys.platform == 'darwin': set_start_method("fork")
+    if sys.platform == 'darwin' and IN_NOTEBOOK: set_start_method("fork")
 except: pass
 
 # Cell

--- a/nbs/03a_parallel.ipynb
+++ b/nbs/03a_parallel.ipynb
@@ -22,14 +22,12 @@
     "from fastcore.xtras import *\n",
     "from functools import wraps\n",
     "\n",
-    "# from contextlib import contextmanager,ExitStack\n",
     "from multiprocessing import Process, Queue\n",
     "import concurrent.futures,time\n",
     "from multiprocessing import Manager, set_start_method\n",
     "from threading import Thread\n",
-    "\n",
     "try:\n",
-    "    if sys.platform == 'darwin': set_start_method(\"fork\")\n",
+    "    if sys.platform == 'darwin' and IN_NOTEBOOK: set_start_method(\"fork\")\n",
     "except: pass"
    ]
   },
@@ -237,7 +235,7 @@
       "text/markdown": [
        "<h4 id=\"ThreadPoolExecutor\" class=\"doc_header\"><code>class</code> <code>ThreadPoolExecutor</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>ThreadPoolExecutor</code>(**`max_workers`**=*`64`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**) :: [`ThreadPoolExecutor`](/parallel.html#ThreadPoolExecutor)\n",
+       "> <code>ThreadPoolExecutor</code>(**`max_workers`**=*`4`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**) :: [`ThreadPoolExecutor`](/parallel.html#ThreadPoolExecutor)\n",
        "\n",
        "Same as Python's ThreadPoolExecutor, except can pass `max_workers==0` for serial execution"
       ],
@@ -292,7 +290,7 @@
       "text/markdown": [
        "<h4 id=\"ProcessPoolExecutor\" class=\"doc_header\"><code>class</code> <code>ProcessPoolExecutor</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>ProcessPoolExecutor</code>(**`max_workers`**=*`64`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**) :: [`ProcessPoolExecutor`](/parallel.html#ProcessPoolExecutor)\n",
+       "> <code>ProcessPoolExecutor</code>(**`max_workers`**=*`4`*, **`on_exc`**=*`print`*, **`pause`**=*`0`*, **\\*\\*`kwargs`**) :: [`ProcessPoolExecutor`](/parallel.html#ProcessPoolExecutor)\n",
        "\n",
        "Same as Python's ProcessPoolExecutor, except can pass `max_workers==0` for serial execution"
       ],
@@ -383,11 +381,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 2022-04-03 01:25:58.938402\n",
-      "1 2022-04-03 01:25:59.189256\n",
-      "2 2022-04-03 01:25:59.439853\n",
-      "3 2022-04-03 01:25:59.691909\n",
-      "4 2022-04-03 01:25:59.943055\n"
+      "0 2022-06-30 09:28:21.811632\n",
+      "1 2022-06-30 09:28:22.062815\n",
+      "2 2022-06-30 09:28:22.314447\n",
+      "3 2022-06-30 09:28:22.565210\n",
+      "4 2022-06-30 09:28:22.816731\n"
      ]
     }
    ],


### PR DESCRIPTION
This fixes parallel on MacOS (in my case, specifically for `nbprocess_test`) by only switching to `fork` start mode if in a notebook. Tests pass on fastcore, nbdev, and fastai.

#### Details

The C code (`matplotlib.backends._macosx`) called when enabling matplotlib on an interactive shell within a `ProcessPoolExecutor` using the `fork` start mode errors with:

```
objc[50313]: +[NSMutableString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```

However, it works with the `forkserver` start mode, which was recommended in [this discussion](https://bugs.python.org/issue33725). I believe we originally switched to `fork` on MacOS because MacOS' default `forkserver` [doesn't work in IPython](https://stackoverflow.com/a/65001152) - that isn't needed on Linux because Linux already defaults to `fork`.

cc @hamelsmu @jph00 