### PR TITLE
fix parallel test on macos

### DIFF
--- a/nbs/03a_parallel.ipynb
+++ b/nbs/03a_parallel.ipynb
@@ -381,11 +381,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 2022-06-30 09:28:21.811632\n",
-      "1 2022-06-30 09:28:22.062815\n",
-      "2 2022-06-30 09:28:22.314447\n",
-      "3 2022-06-30 09:28:22.565210\n",
-      "4 2022-06-30 09:28:22.816731\n"
+      "0 2022-07-01 18:00:33.687478\n",
+      "1 2022-07-01 18:00:33.938175\n",
+      "2 2022-07-01 18:00:34.189594\n",
+      "3 2022-07-01 18:00:34.440545\n",
+      "4 2022-07-01 18:00:34.691130\n"
      ]
     }
    ],
@@ -607,7 +607,7 @@
     "from subprocess import Popen, PIPE\n",
     "# test num_workers > 0 in scripts works when python process start method is spawn\n",
     "process = Popen([\"python\", \"parallel_test.py\"], stdout=PIPE)\n",
-    "_, err = process.communicate(timeout=5)\n",
+    "_, err = process.communicate(timeout=10)\n",
     "exit_code = process.wait()\n",
     "test_eq(exit_code, 0)"
    ]


### PR DESCRIPTION
Timeout after 10 seconds (instead of 5), which I think is due to now using forkserver (instead of fork). 9 seconds was the lowest timeout at which tests passed 10 times consecutively.

[Here's](https://github.com/fastai/fastcore/runs/7143453090?check_suite_focus=true#step:6:81) an example failure on GitHub Actions.

cc @hamelsmu @jph00