### PR TITLE
include annotations and qualname in `copy_func`

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -888,6 +888,8 @@ def copy_func(f):
     fn = FunctionType(f.__code__, f.__globals__, f.__name__, f.__defaults__, f.__closure__)
     fn.__kwdefaults__ = f.__kwdefaults__
     fn.__dict__.update(f.__dict__)
+    fn.__annotations__.update(f.__annotations__)
+    fn.__qualname__ = f.__qualname__
     return fn
 
 # Cell

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -4676,6 +4676,8 @@
     "    fn = FunctionType(f.__code__, f.__globals__, f.__name__, f.__defaults__, f.__closure__)\n",
     "    fn.__kwdefaults__ = f.__kwdefaults__\n",
     "    fn.__dict__.update(f.__dict__)\n",
+    "    fn.__annotations__.update(f.__annotations__)\n",
+    "    fn.__qualname__ = f.__qualname__\n",
     "    return fn"
    ]
   },


### PR DESCRIPTION
This is also split out from (and required by) #415 for easier reviews.

cc @hamelsmu @jph00