### PR TITLE
add nested parser support to `fastcore.script`

### DIFF
--- a/nbs/08_script.ipynb
+++ b/nbs/08_script.ipynb
@@ -526,8 +526,10 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def call_parse(func):\n",
+    "def call_parse(func=None, nested=False):\n",
     "    \"Decorator to create a simple CLI from `func` using `anno_parser`\"\n",
+    "    if func is None: return functools.partial(call_parse, nested=nested)\n",
+    "\n",
     "    mod = inspect.getmodule(inspect.currentframe().f_back)\n",
     "    if not mod: return func\n",
     "\n",
@@ -538,7 +540,9 @@
     "        if not SCRIPT_INFO.func and mod.__name__==\"__main__\": SCRIPT_INFO.func = func.__name__\n",
     "        if len(sys.argv)>1 and sys.argv[1]=='': sys.argv.pop(1)\n",
     "        p = anno_parser(func)\n",
-    "        args = p.parse_args().__dict__\n",
+    "        if nested: args, sys.argv[1:] = p.parse_known_args()\n",
+    "        else: args = p.parse_args()\n",
+    "        args = args.__dict__\n",
     "        xtra = otherwise(args.pop('xtra', ''), eq(1), p.prog)\n",
     "        tfunc = trace(func) if args.pop('pdb', False) else func\n",
     "        tfunc(**merge(args, args_from_prog(func, xtra)))\n",
@@ -584,6 +588,25 @@
    "metadata": {},
    "source": [
     "This is the main way to use `fastcore.script`; decorate your function with `call_parse`, add `Param` annotations (as shown above) or type annotations and docments, and it can then be used as a script."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `nested` keyword argument to create nested parsers, where earlier parsers consume only their known args from `sys.argv` before later parsers are used. This is useful to create one command line application that executes another. For example:\n",
+    "\n",
+    "```sh\n",
+    "myrunner --keyword 1 script.py -- <script.py args>\n",
+    "```\n",
+    "\n",
+    "A separating `--` after the first application's args is recommended though not always required, otherwise args may be parsed in unexpected ways. For example:\n",
+    "\n",
+    "```sh\n",
+    "myrunner script.py -h\n",
+    "```\n",
+    "\n",
+    "would display `myrunner`'s help and not `script.py`'s."
    ]
   },
   {
@@ -640,31 +663,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There are some limitations, see the docs on `--`. Also some behaviour I don't understand, like `nbscript --script_name=update update-union-annots.ipynb -- -h` works as intended, but `nbscript update-union-annots.ipynb --script_name=update -- -h` doesn't. `--` is ignored in the first example but parsed in the second.

Example use-case - run notebooks as scripts:

```python
from fastcore.script import *
from nbprocess.export import nb_export
from nbprocess.processors import _hide_dirs
from pathlib import Path
from runpy import run_path
from tempfile import TemporaryDirectory

def keep_code(cell):
    "Remove cells that aren't exported or hidden (opposite of `rm_export`)"
    if not (cell.directives_ and (cell.directives_.keys() & _hide_dirs) and cell.cell_type == 'code'): del(cell['source'])

@call_parse(nested=True)
def nbscript(nb_path:str, # Notebook path to execute 
             script_name:str=None): # Name of the script used in the help message (default: `nb_path`  with special chars replaced by `_`)
    "Run notebooks as scripts"
    nb_path = Path(nb_path)
    script_name = script_name or nb_path.stem.replace('-','_')
    with TemporaryDirectory() as td:
        lib_path = Path(td)/script_name
        nb_export(nb_path, lib_path)
        run_path(str(lib_path), run_name='__main__')
```