### PR TITLE
conda install command in docs doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ and bringing ideas from NumPy over to Python’s `list` type.
 
 ## Getting started
 
-To install fastcore run: `conda install fastcore` (if you use Anaconda,
-which we recommend) or `pip install fastcore`. For an [editable
+To install fastcore run: `conda install fastcore -c fastai` (if you use
+Anaconda, which we recommend) or `pip install fastcore`. For an
+[editable
 install](https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install),
 clone this repo and run: `pip install -e ".[dev]"`. fastcore is tested
 to work on Ubuntu, macOS and Windows (versions tested are those show
@@ -24,13 +25,13 @@ with the `-latest` suffix
 
 `fastcore` contains many features, including:
 
-- `fastcore.test`: Simple testing functions
-- `fastcore.foundation`: Mixins, delegation, composition, and more
-- `fastcore.xtras`: Utility functions to help with functional-style
-  programming, parallel processing, and more
-- `fastcore.dispatch`: Multiple dispatch methods
-- `fastcore.transform`: Pipelines of composed partially reversible
-  transformations
+-   `fastcore.test`: Simple testing functions
+-   `fastcore.foundation`: Mixins, delegation, composition, and more
+-   `fastcore.xtras`: Utility functions to help with functional-style
+    programming, parallel processing, and more
+-   `fastcore.dispatch`: Multiple dispatch methods
+-   `fastcore.transform`: Pipelines of composed partially reversible
+    transformations
 
 To get started, we recommend you read through [the fastcore
 tour](https://fastcore.fast.ai/000_tour.html).
@@ -47,7 +48,7 @@ To run the tests in parallel, launch `nbdev_test`.
 Before submitting a PR, check that the local library and notebooks
 match.
 
-- If you made a change to the notebooks in one of the exported cells,
-  you can export it to the library with `nbdev_prepare`.
-- If you made a change to the library, you can export it back to the
-  notebooks with `nbdev_update`.
+-   If you made a change to the notebooks in one of the exported cells,
+    you can export it to the library with `nbdev_prepare`.
+-   If you made a change to the library, you can export it back to the
+    notebooks with `nbdev_update`.

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To install fastcore run: `conda install fastcore` (if you use Anaconda, which we recommend) or `pip install fastcore`. For an [editable install](https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install), clone this repo and run: `pip install -e \".[dev]\"`. fastcore is tested to work on Ubuntu, macOS and Windows (versions tested are those show with the `-latest` suffix [here](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources).   \n",
+    "To install fastcore run: `conda install fastcore -c fastai` (if you use Anaconda, which we recommend) or `pip install fastcore`. For an [editable install](https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install), clone this repo and run: `pip install -e \".[dev]\"`. fastcore is tested to work on Ubuntu, macOS and Windows (versions tested are those show with the `-latest` suffix [here](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources).   \n",
     "\n",
     "`fastcore` contains many features, including:\n",
     "\n",
@@ -86,9 +86,18 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.13 ('contrib_fastcore')",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "064fc34fb20f5b8e1f5c5edc91b7ef233dc7a05d098f705dd38d7eaa606fda9b"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello!

I decided to venture into creating a PR regarding #465 . I don't know if it's considered rude to open a PR straight away (I've never done this before), but after a couple of days of opening the issue, I thought I could give it a try because it seemed easy to fix.

The only thing I have done is adding fastai's channel to the `conda` install command and rebuild the docs so that it's reflected in the `README.md` file.

Best regards!