### PR TITLE
Remove dash from heading

### DIFF
--- a/nbs/02_foundation.ipynb
+++ b/nbs/02_foundation.ipynb
@@ -2183,7 +2183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Config -"
+    "## Config"
    ]
   },
   {


### PR DESCRIPTION
For some reason this dash in the heading causes the TOC in the docs to render incorrectly

@jph00 