### PR TITLE
fix: `console_help` excludes entrypoints from the root module

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -558,8 +558,10 @@ def shufflish(x, pct=0.04):
 def console_help(
     libname:str):  # name of library for console script listing
     "Show help for all console scripts from `libname`"
+    from fastcore.style import S
     from pkg_resources import iter_entry_points as ep
     for e in ep('console_scripts'): 
-        if e.module_name.startswith(libname+'.'): 
-            nm = f'\033[1m\033[94m{e.name}\033[0m'
+        if e.module_name == libname or e.module_name.startswith(libname+'.'): 
+            nm = S.bold.light_blue(e.name)
             print(f'{nm:45}{e.load().__doc__}')
+

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -2357,11 +2357,12 @@
     "def console_help(\n",
     "    libname:str):  # name of library for console script listing\n",
     "    \"Show help for all console scripts from `libname`\"\n",
+    "    from fastcore.style import S\n",
     "    from pkg_resources import iter_entry_points as ep\n",
     "    for e in ep('console_scripts'): \n",
-    "        if e.module_name.startswith(libname+'.'): \n",
-    "            nm = f'\\033[1m\\033[94m{e.name}\\033[0m'\n",
-    "            print(f'{nm:45}{e.load().__doc__}')"
+    "        if e.module_name == libname or e.module_name.startswith(libname+'.'): \n",
+    "            nm = S.bold.light_blue(e.name)\n",
+    "            print(f'{nm:45}{e.load().__doc__}')\n"
    ]
   },
   {


### PR DESCRIPTION
Also using `fastcore.style` instead of hardcoded escape codes.