### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,20 @@
 
 ## How to get started
 
-Before anything else, please install the git hooks that run automatic scripts during each commit and merge to strip the notebooks of suerpfluous metadata (and avoid merge conflicts). After cloning the repository, run the following command inside it:
+Clone the `fastcore` repository.
+
+Inside the resulting local repository, run the following command to do an
+[editable
+install](https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install) of the `fastcore` library with tools we use to support development:
+
 ```
-nbdev_install_git_hooks
+pip install -e '.[dev]'
+```
+
+Run the following command to install git hooks that run automatic scripts during each commit and merge. These scripts strip the notebooks of superfluous metadata (and avoid merge conflicts):
+
+```
+nbdev_install_hooks
 ```
 
 ## Did you find a bug?


### PR DESCRIPTION
The most important change here is updating `nbdev_install_git_hooks` to `nbdev_install_hooks`, which I believe is necessary for compatibility with the current version of `nbdev`.