### PR TITLE
fix typo in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Before anything else, please install the git hooks that run automatic scripts during each commit and merge to strip the notebooks of suerpfluous metadata (and avoid merge conflicts). After cloning the repository, run the following command inside it:
 ```
-nbdev_install_git_hooks
+nbdev_install_hooks
 ```
 
 ## Did you find a bug?


### PR DESCRIPTION
newer versions of nbdev use `nbdev_install_hooks` command