### PR TITLE
Fix minor typo in `patch` documentation

### DIFF
--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -5028,7 +5028,7 @@
     "@patch_to(_T4)\n",
     "def greet(self, x): return self.g + x\n",
     "        \n",
-    "t = _T4('hello ') # this sets self.g = 'helllo '\n",
+    "t = _T4('hello ') # this sets self.g = 'hello '\n",
     "test_eq(t.greet('world'), 'hello world') #t.greet('world') will append 'world' to 'hello '"
    ]
   },

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -5005,7 +5005,7 @@
     "@patch_to(_T3)\n",
     "def func1(self, a): return self+a\n",
     "\n",
-    "t = _T3(1) # we initilized `t` to a type int = 1\n",
+    "t = _T3(1) # we initialized `t` to a type int = 1\n",
     "test_eq(t.func1(2), 3) # we add 2 to `t`, so 2 + 1 = 3"
    ]
   },


### PR DESCRIPTION
While reading the docs of [`patch_to`](https://fastcore.fast.ai/basics.html#patch_to) and [`patch`](https://fastcore.fast.ai/basics.html#patch) I found a minor typo: 

```# we initilized `t` to a type int = 1``` which I have changed to ```# we initialized `t` to a type int = 1```

```# this sets self.g = 'helllo '```which was changed to ```# this sets self.g = 'hello '```