### PR TITLE
allow docments to parse async function definitions fixes #527

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import re
 from tokenize import tokenize,COMMENT
-from ast import parse,FunctionDef,AnnAssign
+from ast import parse,FunctionDef,AsyncFunctionDef,AnnAssign
 from io import BytesIO
 from textwrap import dedent
 from types import SimpleNamespace
@@ -69,7 +69,7 @@ def _param_locs(s, returns=True):
     body = _parses(s).body
     if len(body)==1: #or not isinstance(body[0], FunctionDef): return None
         defn = body[0]
-        if isinstance(defn, FunctionDef):
+        if isinstance(defn, (FunctionDef, AsyncFunctionDef)):
             res = {arg.lineno:arg.arg for arg in defn.args.args}
             if returns and defn.returns: res[defn.returns.lineno] = 'return'
             return res

--- a/nbs/06_docments.ipynb
+++ b/nbs/06_docments.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +30,7 @@
     "\n",
     "import re\n",
     "from tokenize import tokenize,COMMENT\n",
-    "from ast import parse,FunctionDef,AnnAssign\n",
+    "from ast import parse,FunctionDef,AsyncFunctionDef,AnnAssign\n",
     "from io import BytesIO\n",
     "from textwrap import dedent\n",
     "from types import SimpleNamespace\n",
@@ -43,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,6 +54,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -60,6 +62,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -67,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -77,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,6 +105,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,6 +127,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -129,6 +135,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -137,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -196,7 +203,7 @@
        " 'Returns': Parameter(name='', type='int', desc=['the result of adding `a` to `b`'])}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +274,7 @@
     "    body = _parses(s).body\n",
     "    if len(body)==1: #or not isinstance(body[0], FunctionDef): return None\n",
     "        defn = body[0]\n",
-    "        if isinstance(defn, FunctionDef):\n",
+    "        if isinstance(defn, (FunctionDef, AsyncFunctionDef)):\n",
     "            res = {arg.lineno:arg.arg for arg in defn.args.args}\n",
     "            if returns and defn.returns: res[defn.returns.lineno] = 'return'\n",
     "            return res\n",
@@ -279,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,6 +399,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -400,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,6 +458,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -458,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -476,7 +485,7 @@
        " 'return': 'the result of adding `a` to `b`'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,6 +502,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -501,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -529,7 +539,7 @@
        "  'default': inspect._empty}}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -539,6 +549,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -547,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -563,7 +574,7 @@
        "{'docment': 'the 1st number to add', 'anno': int, 'default': inspect._empty}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -573,6 +584,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -581,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -618,7 +630,7 @@
        " 'return': \"The result is calculated using Python's builtin `+` operator.\"}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -628,6 +640,41 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Docments works with async functions, too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def add_async(\n",
+    "    # The first operand\n",
+    "    a:int,\n",
+    "    # This is the second of the operands to the *addition* operator.\n",
+    "    # Note that passing a negative value here is the equivalent of the *subtraction* operator.\n",
+    "    b:int,\n",
+    ")->int: # The result is calculated using Python's builtin `+` operator.\n",
+    "    \"Add `a` to `b`\"\n",
+    "    return a+b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(docments(add_async), docments(add))"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -704,6 +751,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -771,6 +819,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -835,6 +884,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -858,6 +908,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -934,6 +985,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -963,6 +1015,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I ran `nbdev_install_hooks` and also `nbdev_clean` against the edited notebook before committing changes. However, it looks like the execution counts are still in the .ipynb file.  

If there's something more/better to do, I can update the request. First time contributing to an nbdev project, so still learning the ropes. 