### PR TITLE
fix backtick

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -145,7 +145,7 @@ class ignore_exceptions:
 
 # %% ../nbs/01_basics.ipynb 55
 def exec_local(code, var_name):
-    "Call `exec` on `code` and return the var `var_name"
+    "Call `exec` on `code` and return the var `var_name`"
     loc = {}
     exec(code, globals(), loc)
     return loc[var_name]

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -823,7 +823,7 @@
    "source": [
     "#|export\n",
     "def exec_local(code, var_name):\n",
-    "    \"Call `exec` on `code` and return the var `var_name\"\n",
+    "    \"Call `exec` on `code` and return the var `var_name`\"\n",
     "    loc = {}\n",
     "    exec(code, globals(), loc)\n",
     "    return loc[var_name]"


### PR DESCRIPTION
@machow is saying that a missing backtick is causing the documentation system to break 

https://github.com/machow/quartodoc/issues/194

Will merge b/c this is minor