### PR TITLE
[Onboarding Experience] Explained how to import fastcore

### DIFF
--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -49,6 +49,8 @@
     "- `fastcore.dispatch`: Multiple dispatch methods\n",
     "- `fastcore.transform`: Pipelines of composed partially reversible transformations\n",
     "\n",
+    "You can import all of fastcore using `from fastcore.all import *`, or import a submodule with e.g. `from fastcore.foundation import *`\n",
+    "\n",
     "To get started, we recommend you read through [the fastcore tour](https://fastcore.fast.ai/tour.html)."
    ]
   },


### PR DESCRIPTION
Hi all,

I found using `fastcore` a bit tedious because it wasn't clear to me how to import it correctly. I now understand that `from fastcore.all import *` or `from fastcore.SUBMODULE import *` is correct.

This PR adds a 1-line-explainer in the Getting Started section of the docs.

As far as I can tell this is not explained anywhere in the docs yet. This would have saved me a lot of time. :)