### PR TITLE
Python 3.12 Deprecation of pkg_resources

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -559,9 +559,9 @@ def console_help(
     libname:str):  # name of library for console script listing
     "Show help for all console scripts from `libname`"
     from fastcore.style import S
-    from pkg_resources import iter_entry_points as ep
-    for e in ep('console_scripts'): 
-        if e.module_name == libname or e.module_name.startswith(libname+'.'): 
+    from importlib.metadata import entry_points as ep_il
+    for e in ep_il(group='console_scripts'): 
+        if e.value == libname or e.value.startswith(libname+'.'): 
             nm = S.bold.light_blue(e.name)
             print(f'{nm:45}{e.load().__doc__}')
 

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -2357,9 +2357,9 @@
     "    libname:str):  # name of library for console script listing\n",
     "    \"Show help for all console scripts from `libname`\"\n",
     "    from fastcore.style import S\n",
-    "    from pkg_resources import iter_entry_points as ep\n",
-    "    for e in ep('console_scripts'): \n",
-    "        if e.module_name == libname or e.module_name.startswith(libname+'.'): \n",
+    "    from importlib.metadata import entry_points as ep_il\n",
+    "    for e in ep_il(group='console_scripts'): \n",
+    "        if e.value == libname or e.value.startswith(libname+'.'): \n",
     "            nm = S.bold.light_blue(e.name)\n",
     "            print(f'{nm:45}{e.load().__doc__}')\n"
    ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from pkg_resources import parse_version
+from packaging.version import Version
 from configparser import ConfigParser
 import setuptools,re,sys
-assert parse_version(setuptools.__version__)>=parse_version('36.2')
+assert Version(setuptools.__version__)>=Version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])


### PR DESCRIPTION
PR fixes DeprecationWarning:

`DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html`

Relevant section:

![image](https://github.com/fastai/fastcore/assets/1515904/2474da73-b2d9-400e-86d0-8893a02a4256)

