### PR TITLE
Remove inline assert on tuple type

### DIFF
--- a/fastcore/xml.py
+++ b/fastcore/xml.py
@@ -29,7 +29,6 @@ def _attrmap(o):
 class FT(list):
     "A 'Fast Tag' structure, which is a `list` of `[tag,children,attrs]`"
     def __init__(self, tag, cs, attrs=None, void_=False, **kwargs):
-        assert isinstance(cs, tuple)
         super().__init__([tag, cs, {**(attrs or {}), **kwargs}])
         self.void_ = void_
 

--- a/nbs/11_xml.ipynb
+++ b/nbs/11_xml.ipynb
@@ -74,7 +74,6 @@
     "class FT(list):\n",
     "    \"A 'Fast Tag' structure, which is a `list` of `[tag,children,attrs]`\"\n",
     "    def __init__(self, tag, cs, attrs=None, void_=False, **kwargs):\n",
-    "        assert isinstance(cs, tuple)\n",
     "        super().__init__([tag, cs, {**(attrs or {}), **kwargs}])\n",
     "        self.void_ = void_\n",
     "\n",


### PR DESCRIPTION
As any type can be sent through, including this assertion of type within the method makes it fragile. While inline assertions for types can make sense under the right conditions (aka Django model responses), this isn't one of those occasions.