### PR TITLE
bugfix

### DIFF
--- a/fastcore/xml.py
+++ b/fastcore/xml.py
@@ -41,7 +41,7 @@ class FT:
     def __repr__(self): return f'{self.tag}({self.children},{self.attrs})'
 
     def __add__(self, b):
-        self.children = self.children + tuplify(b)
+        self.children = list(self.children) + listify(b)
         return self
     
     def __getitem__(self, idx): return self.children[idx]

--- a/nbs/11_xml.ipynb
+++ b/nbs/11_xml.ipynb
@@ -77,7 +77,7 @@
     "    def __repr__(self): return f'{self.tag}({self.children},{self.attrs})'\n",
     "\n",
     "    def __add__(self, b):\n",
-    "        self.children = self.children + tuplify(b)\n",
+    "        self.children = list(self.children) + listify(b)\n",
     "        return self\n",
     "    \n",
     "    def __getitem__(self, idx): return self.children[idx]\n",
@@ -213,7 +213,7 @@
     {
      "data": {
       "text/plain": [
-       "body((div(('hi',),{'a': 1, 'b': True, 'class': None}), p(('hi',),{'class': 'a 1', 'style': 'a:1; b:2'}), p(('a',),{}), p(('b',),{})),{})"
+       "body([div(('hi',),{'a': 1, 'b': True, 'class': None}), p(('hi',),{'class': 'a 1', 'style': 'a:1; b:2'}), p(('a',),{}), p(('b',),{})],{})"
       ]
      },
      "execution_count": null,
@@ -634,7 +634,7 @@
        "```"
       ],
       "text/plain": [
-       "body((div(('Some text ', i(('in italics',),{'spurious': True}), input((),{'name': 'me'}), img((),{'src': 'filename', 'data': 1})),{'style': 'padding:3px'}),),{'class': 'myclass'})"
+       "body([div(['Some text ', i(['in italics'],{'spurious': True}), input((),{'name': 'me'}), img((),{'src': 'filename', 'data': 1})],{'style': 'padding:3px'})],{'class': 'myclass'})"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
@jph00 I was able to resolve the gallery bug, but it involved changing components to use lists instead of tuples when adding.  Making this change, and then updating my `requirements.txt` to install `fastcore` from this branch resolved the issue.

Certain pages failed with a 500 server error on the second request (the first get request would work, but subsequent ones would fail). I could not replicate it locally.  While this fixes the error, I think I am missing part of the story.


The part of the error message related to the fix is here:

```
File "/opt/venv/lib/python3.11/site-packages/fastcore/xml.py", line 44, in __add__
self.children = self.children + tuplify(b)
TypeError: can only concatenate list (not "tuple") to list
```

Full error message from server logs is here

```
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__

await self.middleware_stack(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__

raise exc

File "/opt/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__

await self.app(scope, receive, _send)

File "/opt/venv/lib/python3.11/site-packages/starlette/middleware/sessions.py", line 85, in __call__

await self.app(scope, receive, send_wrapper)

File "/opt/venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 65, in __call__

await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app

raise exc

File "/opt/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app

await app(scope, receive, sender)

File "/opt/venv/lib/python3.11/site-packages/starlette/routing.py", line 754, in __call__

await self.middleware_stack(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/routing.py", line 774, in app

await route.handle(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/routing.py", line 295, in handle

await self.app(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/routing.py", line 77, in app

await wrap_app_handling_exceptions(app, request)(scope, receive, send)

File "/opt/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app

raise exc

File "/opt/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app

await app(scope, receive, sender)

File "/opt/venv/lib/python3.11/site-packages/starlette/routing.py", line 74, in app

response = await f(request)

^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/fasthtml/core.py", line 377, in _endp

if not resp: resp = await _wrap_call(self.f, req, self.sig.parameters)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/fasthtml/core.py", line 356, in _wrap_call

return await _handle(f, wreq)

^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/fasthtml/core.py", line 196, in _handle

return (await f(*args, **kwargs)) if is_async_callable(f) else await run_in_threadpool(f, *args, **kwargs)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/starlette/concurrency.py", line 42, in run_in_threadpool

return await anyio.to_thread.run_sync(func, *args)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync

return await get_async_backend().run_sync_in_worker_thread(

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2177, in run_sync_in_worker_thread

return await future

^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 859, in run

result = context.run(func, *args)

^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/venv/lib/python3.11/site-packages/fastcore/xml.py", line 184, in __call__

if c: self = self+c

~~~~^~

File "/opt/venv/lib/python3.11/site-packages/fastcore/xml.py", line 44, in __add__

self.children = self.children + tuplify(b)

~~~~~~~~~~~~~~^~~~~~~~~~~~

TypeError: can only concatenate list (not "tuple") to list
```