### PR TITLE
add debug=True parameter to urlsend

### DIFF
--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -207,7 +207,7 @@ def summary(self:Request, skip=None)->dict:
     return res
 
 # %% ../nbs/03b_net.ipynb
-def urlsend(url, verb, headers=None, route=None, query=None, data=None, json_data=True,
+def urlsend(url, verb, headers=None, decode=True, route=None, query=None, data=None, json_data=True,
             return_json=True, return_headers=False, debug=None, timeout=None):
     "Send request with `urlrequest`, converting result to json if `return_json`"
     req = urlrequest(url, verb, headers, route=route, query=query, data=data, json_data=json_data)
@@ -216,7 +216,7 @@ def urlsend(url, verb, headers=None, route=None, query=None, data=None, json_dat
     if route and route.get('archive_format', None):
         return urlread(req, decode=False, return_json=False, return_headers=return_headers, timeout=timeout)
 
-    return urlread(req, return_json=return_json, return_headers=return_headers, timeout=timeout)
+    return urlread(req, decode=decode, return_json=return_json, return_headers=return_headers, timeout=timeout)
 
 # %% ../nbs/03b_net.ipynb
 def do_request(url, post=False, headers=None, **data):

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -620,7 +620,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def urlsend(url, verb, headers=None, route=None, query=None, data=None, json_data=True,\n",
+    "def urlsend(url, verb, headers=None, decode=True, route=None, query=None, data=None, json_data=True,\n",
     "            return_json=True, return_headers=False, debug=None, timeout=None):\n",
     "    \"Send request with `urlrequest`, converting result to json if `return_json`\"\n",
     "    req = urlrequest(url, verb, headers, route=route, query=query, data=data, json_data=json_data)\n",
@@ -629,7 +629,7 @@
     "    if route and route.get('archive_format', None):\n",
     "        return urlread(req, decode=False, return_json=False, return_headers=return_headers, timeout=timeout)\n",
     "\n",
-    "    return urlread(req, return_json=return_json, return_headers=return_headers, timeout=timeout)"
+    "    return urlread(req, decode=decode, return_json=return_json, return_headers=return_headers, timeout=timeout)"
    ]
   },
   {


### PR DESCRIPTION
This PR is the first step to solving the issues related and similar to this https://github.com/fastai/ghapi/issues/157

To achieve this the parameter `decode` was added to the `urlsend` function to allow receiving non-JSON responses.

This fixes: https://github.com/fastai/fastcore/issues/608