### PR TITLE
fix annotations generated by py2pyi

### DIFF
--- a/nbs/12_py2pyi.ipynb
+++ b/nbs/12_py2pyi.ipynb
@@ -858,7 +858,16 @@
     "def _update_func(node, sym):\n",
     "    \"\"\"Replace the parameter list of the source code of a function `f` with a different signature.\n",
     "    Replace the body of the function with just `pass`, and remove any decorators named 'delegates'\"\"\"\n",
-    "    node.args = ast_args(sym)\n",
+    "    # sym_args contains the complete set of node args including any delegates kwargs.\n",
+    "    # when adding the delegates kwargs any annotation with a user-defined type is given a fully qualified name (e.g. mod.submod.func).\n",
+    "    # unfortunately the fully qualified names don't match the import statements in the node tree.\n",
+    "    # this can break downstream applications such as \"jump to definition\" in IDEs.\n",
+    "    # to resolve this issue we replace the annotations of user-defined types with the original annotations.\n",
+    "    sym_args = ast_args(sym)\n",
+    "    node_args = {arg.arg: arg.annotation for arg in node.args.args + node.args.kwonlyargs}\n",
+    "    for arg in sym_args.args + sym_args.kwonlyargs:\n",
+    "        arg.annotation = node_args.get(arg.arg, arg.annotation)\n",
+    "    node.args = sym_args\n",
     "    _body_ellip(node)\n",
     "    node.decorator_list = [d for d in node.decorator_list if _deco_id(d) != 'delegates']"
    ]
@@ -907,13 +916,13 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "def g(c, d: test_py2pyi.X, *, b: str='a') -> str:\n",
+       "def g(c, d: X, *, b: str='a') -> str:\n",
        "    \"\"\"I am g\"\"\"\n",
        "    ...\n",
        "```"
       ],
       "text/plain": [
-       "def g(c, d: test_py2pyi.X, *, b: str='a') -> str:\n",
+       "def g(c, d: X, *, b: str='a') -> str:\n",
        "    \"\"\"I am g\"\"\"\n",
        "    ..."
       ]
@@ -973,13 +982,13 @@
      "data": {
       "text/markdown": [
        "```python\n",
-       "def g(c, d: test_py2pyi.X, *, b: str='a') -> str:\n",
+       "def g(c, d: X, *, b: str='a') -> str:\n",
        "    \"\"\"I am g\"\"\"\n",
        "    ...\n",
        "```"
       ],
       "text/plain": [
-       "def g(c, d: test_py2pyi.X, *, b: str='a') -> str:\n",
+       "def g(c, d: X, *, b: str='a') -> str:\n",
        "    \"\"\"I am g\"\"\"\n",
        "    ..."
       ]
@@ -1131,13 +1140,13 @@
       "text/markdown": [
        "```python\n",
        "@patch\n",
-       "def k(self: (test_py2pyi.A, test_py2pyi.B), b: bool=False, *, d: str='a'):\n",
+       "def k(self: (A, B), b: bool=False, *, d: str='a'):\n",
        "    ...\n",
        "```"
       ],
       "text/plain": [
        "@patch\n",
-       "def k(self: (test_py2pyi.A, test_py2pyi.B), b: bool=False, *, d: str='a'):\n",
+       "def k(self: (A, B), b: bool=False, *, d: str='a'):\n",
        "    ..."
       ]
      },

--- a/nbs/test_py2pyi.pyi
+++ b/nbs/test_py2pyi.pyi
@@ -9,7 +9,7 @@ def f(a: int, b: str='a') -> str:
     """I am f"""
     ...
 
-def g(c, d: test_py2pyi.X, *, b: str='a') -> str:
+def g(c, d: X, *, b: str='a') -> str:
     """I am g"""
     ...
 


### PR DESCRIPTION
Currently py2pyi generates fully qualified names (e.g. mod.submod.func) for annotations of user-defined types. These fully qualified names don't match the import statements in the node tree which can break downstream applications such as "jump to definition" in IDEs.

This PR resolves that issue by adding the correct import paths to the annotations.
